### PR TITLE
Update ms.prod slug in docfx.json

### DIFF
--- a/vcpkg/docfx.json
+++ b/vcpkg/docfx.json
@@ -51,7 +51,7 @@
       "ROBOTS": "INDEX,FOLLOW",
       "manager": "roschuma",
       "ms.date": "11/16/2020",
-      "ms.prod": "visual-cpp",
+      "ms.prod": "vcpkg",
       "ms.topic": "conceptual",
       "audience": "developer",
       "defaultDevLang": "cpp",


### PR DESCRIPTION
The Learn metadata allow-list has been updated to include vcpkg in the ms.prod slug. Change docfx.json to use the new value.