### PR TITLE
Refactor manifests.md and registries.md into file-specific references.

### DIFF
--- a/vcpkg/TOC.yml
+++ b/vcpkg/TOC.yml
@@ -6,7 +6,7 @@
       href: examples/installing-and-using-packages.md
     - name: Getting Started with Manifest mode
       href: examples/manifest-mode-cmake.md
-    - name: Manifest Files Reference
+    - name: Manifest mode
       href: users/manifests.md
     - name: Classic mode
       href: users/classic-mode.md
@@ -26,10 +26,14 @@
         href: users/platforms/android.md
       - name: MinGW
         href: users/platforms/mingw.md
-    - name: Consuming Alternate Registries
+    - name: Using Registries
       href: users/registries.md
     - name: Versioning Concepts
       href: users/versioning.concepts.md
+    - name: vcpkg.json Reference
+      href: users/vcpkg-json.md
+    - name: vcpkg-configuration.json Reference
+      href: users/vcpkg-configuration-json.md
     - name: Versioning Reference
       href: users/versioning.md
     - name: Asset Caching

--- a/vcpkg/commands/common-options.md
+++ b/vcpkg/commands/common-options.md
@@ -65,7 +65,7 @@ Defaults to searching upwards from the current working directory for the nearest
 
 ### <a name="overlay-ports"></a> `--overlay-ports=<path>`
 
-Specifies a directory containing [overlay ports](../users/registries.md#configuration-overlay-ports).
+Specifies a directory containing [overlay ports](../users/registries.md#overlays).
 
 This option can be specified multiple times; ports will resolve to the first match.
 

--- a/vcpkg/commands/install.md
+++ b/vcpkg/commands/install.md
@@ -47,7 +47,7 @@ All vcpkg commands support a set of [common options](common-options.md).
 
 Instead of stopping on an unsupported port, continue with a warning.
 
-By default, vcpkg refuses to execute an install plan containing a port installation for a triplet outside its [`"supports"`](../users/manifests.md#supports) clause. The `"supports"` clause of a package describes the full set of platforms a package is expected to be buildable on. This flag instructs vcpkg to warn that the build is expected to fail instead of stopping.
+By default, vcpkg refuses to execute an install plan containing a port installation for a triplet outside its [`"supports"`](../users/vcpkg-json.md#supports) clause. The `"supports"` clause of a package describes the full set of platforms a package is expected to be buildable on. This flag instructs vcpkg to warn that the build is expected to fail instead of stopping.
 
 ### `--clean-after-build`
 
@@ -106,7 +106,7 @@ By default, vcpkg will run several checks on built packages and emit warnings if
 
 Specify an additional [feature](../users/manifests.md#features) from the `vcpkg.json` to install dependencies for.
 
-By default, only [`"dependencies"`](../users/manifests.md#dependencies) and the dependencies of the [`"default-features"`](../users/manifests.md#default-features) will be installed.
+By default, only [`"dependencies"`](../users/vcpkg-json.md#dependencies) and the dependencies of [`"default-features"`](../users/vcpkg-json.md#default-features) will be installed.
 
 ### `--head`
 

--- a/vcpkg/commands/update-baseline.md
+++ b/vcpkg/commands/update-baseline.md
@@ -18,7 +18,7 @@ vcpkg x-update-baseline [options] [--add-initial-baseline] [--dry-run]
 
 Update baselines for all configured [registries](../users/registries.md).
 
-In [Manifest mode](../users/manifests.md), this command operates on all registries in the `vcpkg.json` and the [`vcpkg-configuration.json`](../users/registries.md#vcpkg-configurationjson). In Classic mode, this command operates on the `vcpkg-configuration.json` in the vcpkg instance (`$VCPKG_ROOT`).
+In [Manifest mode](../users/manifests.md), this command operates on all registries in the [`vcpkg.json`](../users/vcpkg-json.md) and the [`vcpkg-configuration.json`](../users/vcpkg-configuration-json.md). In Classic mode, this command operates on the `vcpkg-configuration.json` in the vcpkg instance (`$VCPKG_ROOT`).
 
 See the [versioning documentation](../users/versioning.md#baselines) for more information about baselines.
 
@@ -34,6 +34,6 @@ Print the planned baseline upgrades, but do not modify the files on disk.
 
 - **Manifest mode only**
 
-Add a [`"builtin-baseline"`](../users/manifests.md#builtin-baseline) field to the `vcpkg.json` if it does not already have one.
+Add a [`"builtin-baseline"`](../users/vcpkg-json.md#builtin-baseline) field to the `vcpkg.json` if it does not already have one.
 
 Without this flag, it is an error to run this command on a manifest that does not have any [registries](../users/registries.md) configured.

--- a/vcpkg/contributing/pr-review-checklist.md
+++ b/vcpkg/contributing/pr-review-checklist.md
@@ -36,7 +36,7 @@ See our [Maintainer Guidelines and Policies](maintainer-guide.md#versioning) for
 
 A description only one or a few sentences long is helpful. Consider using the library's official description from their `README.md` or similar if possible. Automatic translations are acceptable and we are happy to clean up translations to English for our contributors.
 
-See our [manifest file documentation](../users/manifests.md#description) for more information.
+See our [manifest file documentation](../users/vcpkg-json.md#description) for more information.
 
 </details>
 

--- a/vcpkg/maintainers/control-files.md
+++ b/vcpkg/maintainers/control-files.md
@@ -150,7 +150,7 @@ Expression that evaluates to true when the port is expected to build successfull
 
 Currently, this field is only used in the CI testing to skip ports. In the future, this mechanism is intended to warn users in advance that a given install tree is not expected to succeed. Therefore, this field should be used optimistically; in cases where a port is expected to succeed 10% of the time, it should still be marked "supported".
 
-See [`"supports"`](../users/manifests.md#supports) in the `vcpkg.json` manifest documentation for the list of supported identifiers.
+See [Platform Expressions](../users/vcpkg-json.md#platform-expression) in the `vcpkg.json` manifest documentation for the list of supported identifiers.
 
 ##### Example
 

--- a/vcpkg/maintainers/functions/vcpkg_fail_port_install.md
+++ b/vcpkg/maintainers/functions/vcpkg_fail_port_install.md
@@ -5,7 +5,7 @@ ms.date: 11/30/2022
 ---
 # vcpkg_fail_port_install
 
-**This function has been deprecated in favor of the [`supports` field](../../users/manifests.md#supports).**
+**This function has been deprecated in favor of the [`supports` field](../../users/vcpkg-json.md#supports).**
 
 Checks common requirements and fails the current portfile with a (default) error message
 

--- a/vcpkg/users/classic-mode.md
+++ b/vcpkg/users/classic-mode.md
@@ -5,7 +5,7 @@ ms.date: 11/30/2022
 ---
 # Classic mode
 
-vcpkg has two primary modes of operation - Classic mode and [Manifest mode](manifests.md). For most users, we recommend Manifest mode.
+vcpkg has two modes for consuming packages - Classic mode and [Manifest mode](manifests.md). For most users, we recommend Manifest mode.
 
 In Classic mode, vcpkg maintains a central *installed tree* inside the vcpkg instance built up by individual [`vcpkg install`](../commands/install.md) and [`vcpkg remove`](../commands/remove.md) commands. This central set of packages can then be shared by any number of projects.
 

--- a/vcpkg/users/config-environment.md
+++ b/vcpkg/users/config-environment.md
@@ -44,7 +44,7 @@ This environment variable can be set to a triplet name which will be used for un
 
 ## VCPKG_OVERLAY_PORTS
 
-This environment variable adds additional [overlay ports](registries.md#configuration-overlay-ports) paths considered after those listed on the command line. List paths to overlays using
+This environment variable adds additional [overlay ports](registries.md#overlays) paths considered after those listed on the command line. List paths to overlays using
 the platform dependent PATH separator (Windows `;` | others `:`)
 
 Example (Windows): `C:\custom-ports\boost;C:\custom-ports\sqlite3`

--- a/vcpkg/users/examples/versioning.getting-started.md
+++ b/vcpkg/users/examples/versioning.getting-started.md
@@ -157,7 +157,7 @@ If you want to upgrade your dependencies, you can bump the minimum version const
 { "builtin-baseline": "3426db05b996481ca31e95fff3734cf23e0f51bc" }
 ```
 
-This field declares the versioning baseline for all ports. Setting a baseline is required to enable versioning, otherwise you will get the current versions on the ports directory. You can run 'git rev-parse HEAD' to get the current commit of vcpkg and set it as the builtin-baseline. See the [`builtin-baseline` documentation](../manifests.md#builtin-baseline) for more information.
+This field declares the versioning baseline for all ports. Setting a baseline is required to enable versioning, otherwise you will get the current versions on the ports directory. You can run 'git rev-parse HEAD' to get the current commit of vcpkg and set it as the builtin-baseline. See the [`"builtin-baseline"` documentation](../vcpkg-json.md#builtin-baseline) for more information.
 
 In our example, you can notice that we do not declare a version constraint for `zlib`; instead, the version is taken from the baseline. Internally, vcpkg will look in commit `3426db05b996481ca31e95fff3734cf23e0f51bc` to find out what version of `zlib` was the latest at that point in time (in our case it was `1.2.11#9`).
 

--- a/vcpkg/users/manifests.md
+++ b/vcpkg/users/manifests.md
@@ -1,13 +1,19 @@
 ---
 title: Manifest mode
-description: Use vcpkg in Manifest mode to configure libraries on a per project basis.
+description: Use a manifest with vcpkg to configure libraries on a per project basis.
 ms.date: 11/30/2022
 ---
 # Manifest mode
 
-Check out the [manifest cmake example](../examples/manifest-mode-cmake.md) for an example project using CMake and manifest mode.
+vcpkg has two modes for consuming packages - [Classic mode](classic-mode.md) and [Manifest mode](manifests.md). For most users, we recommend Manifest mode.
 
-## Simple Example Manifest
+In Manifest mode, vcpkg creates separate *installed trees* for each project and configuration. This allows separate projects to use different versions of libraries. The [`vcpkg.json` file](vcpkg-json.md) and optional [`vcpkg-configuration.json` file](vcpkg-configuration-json.md) form a project's _manifest_. The manifest declares the project's direct dependencies, version constraints, and registries used.
+
+Check out the [manifest CMake example](../examples/manifest-mode-cmake.md) for an example project using CMake and manifest mode.
+
+Check out the [`vcpkg.json` Syntax Reference](vcpkg-json.md) for a full list of fields and functionality.
+
+## Example
 
 ```json
 {
@@ -26,291 +32,89 @@ Check out the [manifest cmake example](../examples/manifest-mode-cmake.md) for a
 }
 ```
 
-## Manifest syntax reference
+## Features
 
-A manifest is a JSON-formatted file named `vcpkg.json` which lies at the root of your project.
-It contains all the information a person needs to know to get dependencies for your project,
-as well as all the metadata about your project that a person who depends on you might be interested in.
+Manifests can define additive sets of functionality, behavior, and dependencies called _features_.
 
-Manifests follow strict JSON: they can't contain C++-style comments (`//`) nor trailing commas. However
-you can use field names that start with `$` to write your comments in any object that has a well-defined set of keys.
-These comment fields are not allowed in any objects which permit user-defined keys (such as `"features"`).
+Each feature should be additive with other features: if a project provides features `A` and `B`, then it should build successfully with both `A` and `B` enabled together. Features should not be used to define alternatives. For example, features cannot be used to choose between multiple, exclusive graphics APIs since it is not possible to choose both. Features can depend on other features within same project if the project's manifest has a [`"name"`](vcpkg-json.md#name).
 
-The latest JSON Schema is available at [vcpkg.schema.json](https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json). IDEs with JSON Schema support such as Visual Studio and Visual Studio Code can use this file to provide IntelliSense and syntax checking. For most IDEs, you should set `"$schema"` in your `vcpkg.json` to this URL (like the above example).
+The set of features available are defined by the [`"features"` field](vcpkg-json.md#features).
 
-Each manifest contains a top level object with the following fields:
+### Example 1: Multiple File Formats
 
-### <a id="name"></a> `"name"`
-
-This is the name of your project! It must be formatted in a way that vcpkg understands - in other words,
-it must be lowercase alphabetic characters, digits, and hyphens, and it must not start nor end with a hyphen.
-For example, `Boost.Asio` might be given the name `boost-asio`.
-
-### Version fields
-
-There are four version field options, depending on how the port orders its
-releases.
-
-- [`"version"`](versioning.md#version) - Generic, dot-separated numeric
-  sequence.
-- [`"version-semver"`](versioning.md#version-semver) - [Semantic Version
-  2.0.0](https://semver.org/#semantic-versioning-specification-semver)
-- [`"version-date"`](versioning.md#version-date) - Used for packages which do
-  not have numeric releases (for example, Live-at-HEAD). Matches `YYYY-MM-DD`
-  with optional trailing dot-separated numeric sequence.
-- [`"version-string"`](versioning.md#version-string) - Used for packages that
-  don't have orderable versions. This should be rarely used, however all ports
-  created before the other version fields were introduced use this scheme.
-
-Additionally, the optional `"port-version"` field is used to indicate revisions
-to the port with the same upstream source version. For pure consumers, this
-field should not be used.
-
-See [versioning](versioning.md#version-schemes) for more details.
-
-### <a id="description"></a> `"description"`
-
-This is where you describe your project. Give it a good description to help in searching for it!
-This can be a single string, or it can be an array of strings;
-in the latter case, the first string is treated as a summary,
-while the remaining strings are treated as the full description.
-
-### <a id="builtin-baseline"></a> `"builtin-baseline"`
-
-This field indicates the commit of vcpkg which provides global minimum version
-information for your manifest.
-
-It is required for top-level manifest files using versioning without a specified [`"default-registry"`](registries.md#configuration-default-registry). It has the same semantic as defining your default registry to be:
+For example, an image manipulation library might optionally support several different image types by depending on different sets of other libraries.
 
 ```json
 {
-  "default-registry": {
-    "kind": "builtin",
-    "baseline": "<value>"
-  }
-}
-```
-
-See [versioning](versioning.md#baselines) for more semantic details.
-
-### <a id="dependencies"></a> `"dependencies"`
-
-This field lists all the dependencies you'll need to build your library (as well as any your dependents might need,
-if they were to use you). It's an array of strings and objects:
-
-- A string dependency (e.g., `"dependencies": [ "zlib" ]`) is the simplest way one can depend on a library;
-  it means you don't depend on a single version, and don't need to write down any more information.
-- On the other hand, an object dependency (e.g., `"dependencies": [ { "name": "zlib" } ]`)
-  allows you to add that extra information.
-
-#### Example
-
-```json
-"dependencies": [
-  {
-    "name": "arrow",
-    "default-features": false,
-    "features": [ "json" ]
-  },
-  "boost-asio",
-  "openssl",
-  {
-    "name": "picosha2",
-    "platform": "!windows"
-  }
-]
-```
-
-#### <a name="dependencies-name"></a> `"name"` field
-
-The name of the dependency. This follows the same restrictions as the [`"name"`](#name) property for a project.
-
-#### <a name="dependencies-default-features"></a> <a name="dependencies-features"></a> `"features"` and `"default-features"` fields
-
-`"features"` is an array of feature names which tell you the set of features that the
-dependencies need to have at a minimum,
-while `"default-features"` is a boolean that tells vcpkg whether or not to
-install the features the package author thinks should be "most common for most people to use".
-
-For example, `ffmpeg` is a library which supports many, many audio and video codecs;
-however, for your specific project, you may only need mp3 encoding.
-Then, you might just ask for:
-
-```json
-{
-  "name": "ffmpeg",
-  "default-features": false,
-  "features": [ "mp3lame" ]
-}
-```
-
-#### <a name="host"></a> `"host"` field
-
-A boolean indicating that the dependency must be built for the [host triplet](host-dependencies.md) instead of the current port's triplet. Defaults to `false`.
-
-Any dependency that provides tools or scripts which should be "executed" during a build (such as buildsystems, code generators, or helpers) should be marked as `"host": true`. This enables correct cross-compilation in cases that the target is not executable -- such as when compiling for `arm64-android`.
-
-See [Host dependencies](host-dependencies.md) for more information.
-
-#### <a name="platform"></a> `"platform"` field
-
-The `"platform"` field limits the platforms where the dependency is required.
-
-Some predefined values are computed from the [triplet settings](triplets.md):
-
-- `x64` - `VCPKG_TARGET_ARCHITECTURE` == `"x64"`
-- `x86` - `VCPKG_TARGET_ARCHITECTURE` == `"x86"`
-- `arm` - `VCPKG_TARGET_ARCHITECTURE` == `"arm"` or `VCPKG_TARGET_ARCHITECTURE` == `"arm64"`
-- `arm64` - `VCPKG_TARGET_ARCHITECTURE` == `"arm64"`
-- `wasm32` - `VCPKG_TARGET_ARCHITECTURE` == `"wasm32"`
-- `windows` - `VCPKG_CMAKE_SYSTEM_NAME` == `""` or `VCPKG_CMAKE_SYSTEM_NAME` == `"WindowsStore"` or `VCPKG_CMAKE_SYSTEM_NAME` == `"MinGW"`
-- `mingw` - `VCPKG_CMAKE_SYSTEM_NAME` == `"MinGW"`
-- `uwp` - `VCPKG_CMAKE_SYSTEM_NAME` == `"WindowsStore"`
-- `linux` - `VCPKG_CMAKE_SYSTEM_NAME` == `"Linux"`
-- `osx` - `VCPKG_CMAKE_SYSTEM_NAME` == `"Darwin"`
-- `ios` - `VCPKG_CMAKE_SYSTEM_NAME` == `"iOS"`
-- `freebsd` - `VCPKG_CMAKE_SYSTEM_NAME` == `"FreeBSD"`
-- `openbsd` - `VCPKG_CMAKE_SYSTEM_NAME` == `"OpenBSD"`
-- `android` - `VCPKG_CMAKE_SYSTEM_NAME` == `"Android"`
-- `emscripten` - `VCPKG_CMAKE_SYSTEM_NAME` == `"Emscripten"`
-- `static` - `VCPKG_LIBRARY_LINKAGE` == `"static"`
-- `static-crt` - `VCPKG_CRT_LINKAGE` == `"static"`
-
-Cross-compiling can be detected with the `native` value:
-
-- `native` - `TARGET_TRIPLET` == `HOST_TRIPLET`
-
-Expressions can also be combined using logical operators and grouping:
-
-- `!<expr>`, `not <expr>` - negation
-- `<expr>|<expr>`, `<expr>||<expr>`, `<expr>,<expr>`, `<expr> or <expr>` - logical OR
-- `<expr>&<expr>`, `<expr>&&<expr>`, `<expr> and <expr>` - logical AND
-- `(<expr>)` - grouping/precedence
-
-##### Examples
-
-- **Needs `picosha2` for sha256 on non-Windows, but get it from the OS on Windows (BCrypt)**
-
-```jsonc
-{
-  "name": "picosha2",
-  "platform": "!windows"
-}
-```
-
-- **Require zlib on arm64 Windows and amd64 Linux**
-
-```jsonc
-{
-  "name": "zlib",
-  "platform": "(windows & arm64) | (linux & x64)"
-}
-```
-
-#### <a name="version-gt"></a> `"version>="` field
-
-A minimum version constraint on the dependency.
-
-This field specifies the minimum version of the dependency, optionally using a
-`#N` suffix to denote port-version if non-zero.
-
-For more information on versioning semantics, see [Versioning](versioning.md#version).
-
-### <a name="overrides"></a> `"overrides"`
-
-This field pins exact versions for individual dependencies.
-
-`"overrides"` from transitive manifests (i.e. from dependencies) are ignored.
-
-See also [versioning](versioning.md#overrides) for more semantic details.
-
-#### Example
-
-```json
-  "overrides": [
-    {
-      "name": "arrow", "version": "1.2.3", "port-version": 7
-    }
-  ]
-```
-
-### <a name="supports"></a> `"supports"`
-
-If your project doesn't support common platforms, you can tell your users this with the `"supports"` field. It uses the same platform expressions as [`"platform"`](#platform), from dependencies, as well as the `"supports"` field of features.
-
-For example, if your library doesn't support linux, you might write `{ "supports": "!linux" }`.
-
-### <a name="default-features"></a> <a name="features"></a> `"features"` and `"default-features"`
-
-The `"features"` field defines _your_ project's optional features, that others may either depend on or not. It's an object, where the keys are the names of the features, and the values are objects describing the feature. `"description"` is required, and acts exactly like the [`"description"`](#description) field on the global package, and `"dependencies"` are optional, and again act exactly like the [`"dependencies"`](#dependencies) field on the global package. There's also the `"supports"` field, which again acts exactly like the [`"supports"`](#supports) field on the global package.
-
-You also have control over which features are default, if a person doesn't ask for anything specific, and that's the `"default-features"` field, which is an array of feature names.
-
-#### Example
-
-```json
-{
-  "name": "libdb",
-  "version": "1.0.0",
-  "description": [
-    "An example database library.",
-    "Optionally can build with CBOR, JSON, or CSV as backends."
-  ],
-  "$default-features-explanation": "Users using this library transitively will get all backends automatically",
-  "default-features": [ "cbor", "csv", "json" ],
+  "name": "my-image-lib",
+  "version": "0.1",
   "features": {
-    "cbor": {
-      "description": "The CBOR backend",
-      "dependencies": [
-        {
-          "$explanation": [
-            "This is how you tell vcpkg that the cbor feature depends on the json feature of this package"
-          ],
-          "name": "libdb",
-          "default-features": false,
-          "features": [ "json" ]
-        }
-      ]
-    },
-    "csv": {
-      "description": "The CSV backend",
-      "dependencies": [
-        "fast-cpp-csv-parser"
-      ]
-    },
-    "json": {
-      "description": "The JSON backend",
-      "dependencies": [
-        "jsoncons"
-      ]
-    }
+    "png": { "description": "Support PNG files", "dependencies": ["libpng"]},
+    "jpeg": { "description": "Support JPEG files", "dependencies": ["libjpeg-turbo"]},
+    "tiff": { "description": "Support TIFF files", "dependencies": ["libtiff"]},
   }
 }
 ```
 
-### `"vcpkg-configuration"`
-
-Allows to embed vcpkg configuration properties inside the `vcpkg.json` file. Everything inside the `vcpkg-configuration` property is treated as if it were defined in a `vcpkg-configuration.json` file. For more details, see the [`vcpkg-configuration.json`](registries.md) documentation.
-
-Having a `vcpkg-configuration` defined in `vcpkg.json` while also having a `vcpkg-configuration.json` file is not allowed and will result in the vcpkg command terminating with an error message.
-
-#### Example
+In a single dependency graph, multiple libraries can depend on features from a common core library.
 
 ```json
-  "name": "test",
-  "version": "1.0.0",
-  "dependencies": [ "beison", "zlib" ],
-  "vcpkg-configuration": {
-    "registries": [
-      {
-        "kind": "git",
-        "baseline": "dacf4de488094a384ca2c202b923ccc097956e0c",
-        "repository": "https://github.com/northwindtraders/vcpkg-registry",
-        "packages": [ "beicode", "beison" ]
-      }
-    ],
-    "overlay-ports": [ "./my-ports/fmt", 
-                       "./team-ports"
-    ]
-  }
+{
+  "name": "library-a",
+  "version": "1",
+  "dependencies": [{"name": "my-image-lib", "features": ["png"]}]
+}
 ```
+```json
+{
+  "name": "library-b",
+  "version": "1",
+  "dependencies": [{"name": "my-image-lib", "features": ["jpeg"]}]
+}
+```
+
+When resolving these dependencies, all required features and dependencies will be unioned together. In this example, if a top-level project used `library-a` and `library-b`, they would see an install plan similar to:
+
+```
+libjpeg-turbo[core]
+libpng[core]
+library-a[core]
+library-b[core]
+my-image-lib[core,png,jpeg]
+```
+
+The build of `my-image-lib` would activate PNG and JPEG support but deactivate TIFF support.
+
+### Example 2: Multiple Related Projects in a Single Repository
+
+When a single repository contains several separate buildable components, for example client and server applications with some shared code, developers of each piece may want to avoid installing expensive dependencies required by other pieces.
+
+```json
+{
+  "name": "my-game",
+  "dependencies": ["grpc"],
+  "features": {
+    "client": { "description": "Client Game Executable", "dependencies": ["sdl2", "bullet3"]},
+    "server": { "description": "Multiplayer Server Executable", "dependencies": ["proxygen"]},
+    "tests": { "description": "Build tests", "dependencies": ["gtest"] }
+  }
+}
+```
+
+Individual developers can then select which features to install:
+
+- On the [install command line](../commands/install.md), pass [`--x-feature=`](../commands/install.md#feature)
+- When using [CMake Integration](buildsystems/cmake-integration.md), set [`VCPKG_MANIFEST_FEATURES`](buildsystems/cmake-integration.md#vcpkg_manifest_features) before the `project()` command.
+- When using [MSBuild Integration](buildsystems/msbuild-integration.md), pass `--x-feature=` via [`VcpkgAdditionalInstallOptions`](buildsystems/msbuild-integration.md#vcpkg-additional-install-options)
+
+### Default Features
+
+Default features are a set of features to be automatically activated if the top-level project does not explicitly request a build without them. Default features are intended to ensure a minimum level of functionality regardless of how complex and customizable the dependency graph of a project grows. They are not intended to model "curation" or "suggestions".
+
+For example, consider a library `"extract-any"` that supports over 10 different archive formats, including several that are quite obscure. Because they are all optional, if none are selected the library is not functional: it cannot extract any files.
+
+Default features ensure that a user simply running:
+```
+vcpkg install extract-any
+```
+will get a baseline level of functionality, for example automatically selecting `.zip` and `.tar.gz` decompressors.

--- a/vcpkg/users/registries.md
+++ b/vcpkg/users/registries.md
@@ -1,97 +1,17 @@
 ---
-title: Using registries
+title: Using Registries
 description: Understand the use and content of registries in vcpkg.
 ms.date: 11/30/2022
 ---
-# Using registries
+# Using Registries
 
 For information on creating your own registries, see [Creating Registries](../users/registries.md).
 
-## `vcpkg-configuration.json`
+vcpkg uses _Registries_ to manage ports and versions. By default, vcpkg finds libraries from the public curated registry at https://github.com/microsoft/vcpkg. This default set can be extended by adding additional registry definitions or replaced with your own mirror of the public registry.
 
-From a high level perspective, everything that a project needs to define
-about registries is contained in the vcpkg configuration file. In classic
-mode, the configuration file lies in the vcpkg root; for manifest mode,
-the file must exist next to the project's `vcpkg.json` file.
-This file is named `vcpkg-configuration.json`, and it's a simple top-level
-object file.
+Registries are configured in the [`vcpkg-configuration.json`](vcpkg-configuration-json.md).
 
-### Registry Objects
-
-Registries are defined in JSON as objects. They must contain at least the
-`"kind"` and `"baseline"` fields, and additionally the different kinds of
-registry will have their own way of defining where the registry can be found:
-
-- git registries require the `"repository"` field
-- filesystem registries require the `"path"` field
-- built-in registries do not require a field, since there is only one
-  built-in registry.
-
-#### Registry Objects: `"kind"`
-
-The `"kind"` field must be a string:
-
-- For git registries: `"git"`
-- For filesystem registries: `"filesystem"`
-- For the builtin registry: `"builtin"`
-
-#### Registry Objects: `"baseline"`
-
-The `"baseline"` field must be a string. It defines a minimum version for all packages coming from this registry configuration.
-
-For [Git Registries](../maintainers/registries.md#git-registries) and for the [Builtin Registry](../maintainers/registries.md#builtin-registries), it should be a 40-character git commit sha in the registry's repository that contains a `versions/baseline.json`.
-
-For [Filesystem Registries](../maintainers/registries.md#filesystem-registries), it can be any valid baseline string that the registry defines.
-
-#### Registry Objects: `"repository"`
-
-This should be a string, of any repository format that git understands:
-
-- `"https://github.com/microsoft/vcpkg"`
-- `"git@github.com:microsoft/vcpkg"`
-- `"/dev/vcpkg-registry"`
-
-#### Registry Objects: `"path"`
-
-This should be a path; it can be either absolute or relative; relative paths
-will be based at the directory the `vcpkg-configuration.json` lives in.
-
-### Configuration: `"default-registry"`
-
-The `"default-registry"` field should be a registry object. It defines
-the registry that is used for all packages that are not claimed by any
-package registries. It may also be `null`, in which case no packages that
-are not claimed by package registries may be installed.
-
-### Configuration: `"registries"`
-
-The `"registries"` field should be an array of registry objects, each of
-which additionally contain a `"packages"` field, which should be an array of
-package names. These define the package registries, which are used for 
-the specific packages named by the `"packages"` field.
-
-The `"packages"` fields of all the package registries must be disjoint.
-
-### Configuration: `"overlay-ports"`
-
-An array of port overlay paths.
-
-Each path in the array must point to either:
-
-- a particular port directory (a directory containing `vcpkg.json` and `portfile.cmake`), or
-- a directory containing port directories.
-
-Relative paths are resolved relative to the `vcpkg-configuration.json` file. Absolute paths can be used but are discouraged.
-
-### Configuration: `"overlay-triplets"`
-
-An array of triplet overlay paths.
-
-Each path in the array must point to a directory of triplet files ([see triplets documentation](triplets.md)). Relative paths are resolved relative to the `vcpkg-configuration.json` file. Absolute paths can be used but are discouraged.
-
-### Example Configuration File
-
-Let's assume that you have mirrored <https://github.com/microsoft/vcpkg> at <https://git.example.com/vcpkg>: this will be your default registry. Additionally, you want to use North Wind Trader's registry for their beison and beicode libraries, as well as configure overlay ports and overlay triplets from your custom directories. The following `vcpkg-configuration.json` will work:
+## Example vcpkg-configuration.json
 
 ```json
 {
@@ -107,14 +27,10 @@ Let's assume that you have mirrored <https://github.com/microsoft/vcpkg> at <htt
       "baseline": "dacf4de488094a384ca2c202b923ccc097956e0c",
       "packages": [ "beicode", "beison" ]
     }
-  ],
-  "overlay-ports": [ "./team-ports",
-                     "c:/project/my-ports/fmt",
-                     "./custom-ports"
-   ],
-  "overlay-triplets": [ "./my-triplets" ]
+  ]
 }
 ```
+This example adds a private registry, `https://github.com/northwindtraders/vcpkg-registry`, as the source for the libraries `beicode` and `beison`. All other ports are found from an internal mirror of the Curated Catalog hosted at `https://internal/mirror/of/github.com/Microsoft/vcpkg`.
 
 ## Package name resolution
 
@@ -124,29 +40,20 @@ the registry that a package is fetched from. Just from
 `vcpkg-configuration.json`, one can tell exactly from which registry a
 package definition will be fetched from.
 
-The name resolution algorithm is as follows:
+The name resolution algorithm is:
 
-- If the name matches an [overlay](#overlays-resolution), use that overlay; otherwise
-- If there is a package registry that claims the package name,
-  use that registry; otherwise
-- If there is a default registry defined, use that registry; otherwise
-- If the default registry is set to `null`, error out; otherwise
-- use the built-in registry.
+- If the name matches an [overlay](#overlays), use that overlay; otherwise
+- If there is a [`"packages"`](vcpkg-configuration-json.md#registry-packages) list that matches the port name, use that registry; otherwise
+- If the [default registry](vcpkg-configuration-json.md#default-registry) is not `null`, use that registry; otherwise
+- Fail to associate the port with a registry.
 
-### Overlays resolution
+## <a name="overlays"></a> Overlays
 
-Overlay ports and triplets are evaluated in this order:
+Overlays are a way to extend vcpkg with additional ports (without creating a full registry) and additional triplets. Overlays are considered before performing any registry lookups or versioning and will replace any builtin triplets or ports.
 
-1. Overlays from the [command line](../commands/common-options.md)
-1. Overlays from `vcpkg-configuration.json`
-1. Overlays from the `VCPKG_OVERLAY_[PORTS|TRIPLETS]` [environment](config-environment.md) variable.
+Overlay settings are evaluated in this order:
 
-Additionally, each method has its own evaluation order:
+1. Overlays from the [command line](../commands/common-options.md#overlay-ports) in the order passed; then
+2. Overlays from [`vcpkg-configuration.json`](vcpkg-configuration-json.md#overlay-ports) in order; then
+3. Overlays from the `VCPKG_OVERLAY_[PORTS|TRIPLETS]` [environment variables](config-environment.md#vcpkg_overlay_ports) in order
 
-- Overlays from the command line are evaluated from left-to-right in the order each argument is passed, with each `--overlay-[ports|triplets]` argument adding a new overlay location.
-- Overlays from `vcpkg-configuration.json` are evaluated in the order of the `"overlay-[ports|triplets]"` array.
-- Overlays set by `VCPKG_OVERLAY_[PORTS|TRIPLETS]` are evaluated from left-to-right. Overlay locations are separated by an OS-specific path separator (`;` on Windows and `:` on non-Windows).
-
-### Versioning support
-
-Versioning with custom registries works exactly as it does in the built-in registry. You can read more about that in the [versioning documentation](versioning.md).

--- a/vcpkg/users/triplets.md
+++ b/vcpkg/users/triplets.md
@@ -167,9 +167,9 @@ Also available as build-type specific `VCPKG_MAKE_CONFIGURE_OPTIONS_DEBUG` and `
 
 Replaces the default computed list of triplet "Supports" terms.
 
-This option (if set) will override the default set of terms used for qualified dependency resolution and "Supports" field evaluation.
+This option (if set) will override the default set of terms used for [Platform Expression](vcpkg-json.md#platform-expression) evaluation.
 
-See the [`"supports"`](manifests.md#supports) manifest file field documentation for more details.
+See the [`"supports"`](vcpkg-json.md#supports) manifest file field documentation for more details.
 
 > Implementers' note: this list is extracted via the `vcpkg_get_dep_info` mechanism.
 

--- a/vcpkg/users/vcpkg-configuration-json.md
+++ b/vcpkg/users/vcpkg-configuration-json.md
@@ -1,0 +1,143 @@
+---
+title: vcpkg-configuration.json Reference
+description: Reference documentation for the vcpkg-configuration.json file format
+ms.date: 11/30/2022
+---
+# vcpkg-configuration.json Reference
+
+The `vcpkg-configuration.json` file forms part of a project's [manifest](manifests.md), along with [`vcpkg.json`](vcpkg-json.md). All fields in the `vcpkg-configuration.json` file are only used from the top-level project -- the `vcpkg-configuration.json` files in any dependencies are ignored.
+
+In [Manifest Mode](manifests.md), `vcpkg-configuration.json` can be in a separate file beside [`vcpkg.json`](vcpkg-json.md) or it can be embedded in the [`"vcpkg-configuration" field`](vcpkg-json.md#vcpkg-configuration).
+
+In [Classic Mode](classic-mode.md), vcpkg will use the `vcpkg-configuration.json` file in the [root](../commands/common-options.md#vcpkg-root) of the vcpkg instance.
+
+For an overview of using registries with vcpkg, see [Using Registries](registries.md).
+
+## Example
+
+```json
+{
+  "default-registry": {
+    "kind": "git",
+    "repository": "https://internal/mirror/of/github.com/Microsoft/vcpkg",
+    "baseline": "eefee7408133f3a0fef711ef9c6a3677b7e06fd7"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/northwindtraders/vcpkg-registry",
+      "baseline": "dacf4de488094a384ca2c202b923ccc097956e0c",
+      "packages": [ "beicode", "beison" ]
+    }
+  ],
+  "overlay-ports": [
+    "./team-ports",
+    "./custom-ports"
+   ],
+  "overlay-triplets": [ "./my-triplets" ]
+}
+```
+This example adds a private registry, `https://github.com/northwindtraders/vcpkg-registry`, as the source for the libraries `beicode` and `beison`. All other ports are found from an internal mirror of the Curated Catalog hosted at `https://internal/mirror/of/github.com/Microsoft/vcpkg`.
+
+The example also configures custom overlays for ports and triplets that are present in the source code repository.
+
+## Top-level Fields
+
+| Name | Type   | Description |
+|------|--------|-------------|
+| [default-registry](#default-registry) | [Registry][] \| null | Registry used for all ports without a specific registry |
+| [overlay-ports](#overlay-ports) | string[] | List of paths to use as port overlays |
+| [overlay-triplets](#overlay-triplets) | string[] | List of paths to use as triplet overlays |
+| [registries](#registries) | [Registry][][] | Additional registries to use for subsets of ports |
+
+### <a name="default-registry"></a> `"default-registry"`
+
+The registry to use for all ports without a more specific registry. A [Registry][] or null. Optional.
+
+Ports that do not match a [`"packages"`](#registry-packages) specifier come from the default registry. If the default registry is specified as `null`, ports that do not match will fail to be found. If the default registry is omitted, it will implicitly be set to a [Builtin Registry][] using the value of [`"builtin-baseline"`](vcpkg-json.md#builtin-baseline) as the [`"baseline"`](#registry-baseline).
+
+### <a name="registries"></a> `"registries"`
+
+Additional registries to use for specific ports. An array of [Registries](#registry). Optional.
+
+### <a name="overlay-ports"></a> `"overlay-ports"`
+
+A list of port overlay paths. An array of strings. Optional.
+
+Each path in the array must point to either:
+
+- A port directory containing `vcpkg.json` and `portfile.cmake`
+- A directory containing port directories named after the ports (`zlib`'s `vcpkg.json` must be at `zlib/vcpkg.json`).
+
+Relative paths are resolved relative to the `vcpkg-configuration.json` file. Absolute paths can be used but are discouraged.
+
+### <a name="overlay-triplets"></a> `"overlay-triplets"`
+
+A list of triplet overlay paths. An array of strings. Optional.
+
+Each path in the array must point to a directory of triplet files ([see triplets documentation](triplets.md)). Relative paths are resolved relative to the `vcpkg-configuration.json` file. Absolute paths can be used but are discouraged.
+
+## <a name="registry"></a> Registry Fields
+
+| Name | Required | Type   | Description |
+|------|----------|--------|-------------|
+| [baseline](#registry-baseline) | Yes | string | Minimum version constraint on all ports from this registry |
+| [kind](#registry-kind) | Yes | string | Type of registry being used |
+| [packages](#registry-packages) | Yes, if not default | string | List of ports to come from this registry |
+| [path](#registry-path) | Filesystem Registry | string | Path to the Filesystem registry |
+| [reference](#registry-reference) | No | string | Git reference to use for available versions |
+| [repository](#registry-repository) | Git Registry | string | URI of the Git registry |
+
+[Registry]: #registry
+
+### <a name="registry-kind"></a> [Registry][]: `"kind"`
+
+The type of registry being used. A string. Required.
+
+| `"kind"` Value | Registry Type |
+| ------|---|
+| `"filesystem"` | [Filesystem Registry][] |
+| `"git"` | [Git Registry][] |
+| `"builtin"` | [Builtin Registry][] |
+
+### <a name="registry-baseline"></a> [Registry][]: `"baseline"`
+
+The registry-specific identifier for the minimum versions to use from this registry. A string. Required.
+
+For [Git Registries][Git Registry] and for the [Builtin Registry][], it should be a 40-character git commit sha in the registry's repository that contains a `versions/baseline.json`.
+
+For [Filesystem Registries][Filesystem Registry], it can be any valid baseline string that the registry defines.
+
+### <a name="registry-reference"></a> [Registry][]: `"reference"`
+
+The Git reference used to list available versions of a [Git Registry][]. A string. Optional.
+
+If not specified, defaults to `HEAD`. This field can be a topic branch to access versions that are not yet fully published.
+
+### <a name="registry-repository"></a> [Registry][]: `"repository"`
+
+The URI of the [Git Registry][]. A string. Required for Git Registries.
+
+The string can be any URI format that Git understands:
+
+- `"https://github.com/microsoft/vcpkg"`
+- `"git@github.com:microsoft/vcpkg"`
+- `"/dev/vcpkg-registry"`
+
+Relative paths have unspecified behavior that will change in future versions of vcpkg.
+
+### <a name="registry-path"></a> [Registry][]: `"path"`
+
+The path to the [Filesystem Registry][]. A string. Required for Filesystem Registries.
+
+Relative paths are resolved relative to the `vcpkg-configuration.json`.
+
+### <a name="registry-packages"></a> [Registry][]: `"packages"`
+
+The list of ports to come from this registry. An array of strings. Required for all non-default registries.
+
+See the [Using Registries documentation](registries.md#package-name-resolution) for more information on how port names are resolved.
+
+[Git Registry]: ../maintainers/registries.md#git-registries
+[Filesystem Registry]: ../maintainers/registries.md#filesystem-registries
+[Builtin Registry]: ../maintainers/registries.md#builtin-registries

--- a/vcpkg/users/vcpkg-json.md
+++ b/vcpkg/users/vcpkg-json.md
@@ -1,0 +1,395 @@
+---
+title: vcpkg.json Reference
+description: Reference documentation for the vcpkg.json file format.
+ms.date: 11/30/2022
+---
+# vcpkg.json Reference
+
+For an overview of using manifests with vcpkg, see [Manifest mode](manifests.md).
+
+Manifests are strict [JSON](https://www.json.org) documents. They cannot contain C++-style comments (`//`) nor trailing commas. However you can use field names that start with `$` to write your comments in any object that has a well-defined set of keys. These comment fields are not allowed in any objects which permit user-defined keys (such as `"features"`).
+
+The latest JSON Schema is available at [vcpkg.schema.json](https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json). IDEs with JSON Schema support such as Visual Studio and Visual Studio Code can use this file to provide IntelliSense and syntax checking. For most IDEs, you should set `"$schema"` in your `vcpkg.json` to this URL (like the above example).
+
+## Example
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "dependencies": [
+    "boost-system",
+    {
+      "name": "cpprestsdk",
+      "default-features": false
+    },
+    "libxml2",
+    "yajl"
+  ]
+}
+```
+
+This example demonstrates a manifest for an application using `boost-system`, `cpprestsdk`, `libxml2`, and `yajl`. The example also includes a `$schema` reference to enable better IDE validation and autocompletion.
+
+## Top-level Fields
+
+| Name | Required | Type   | Description |
+|------|----------|--------|-------------|
+| [builtin-baseline](#builtin-baseline) | No | string | Version pins to use when building as top-level |
+| [description](#description) | Libraries | string or string[] | The project description |
+| [dependencies](#dependencies) | No | [Dependency][][] | List of dependencies required to build and use this project |
+| [default-features](#default-features) | No | bool | Require the [features](manifests.md#features) listed as on-by-default |
+| [features](#features) | No | {string: [Feature](#feature)} | Optional [features](manifests.md#features) available for users of the project |
+| [name](#name) | Libraries      | string | The project name |
+| [overrides](#overrides) | No | Override[] | Version pins to use when building as top-level |
+| [port-version](#port-version) | No | integer | Packaging scripts revision |
+| [supports](#supports) | No | [Platform Expression][] | Supported platform and build configurations |
+| [version<br>version-semver<br>version-date<br>version-string](#version) | Libraries | string | Upstream version information |
+
+### <a id="name"></a> `"name"`
+
+The name of the project. A string. Required for libraries, optional for top-level projects.
+
+The name must be lowercase ASCII letters, digits, or hyphens (`-`). It must not start nor end with a hyphen. Libraries are encouraged to include their organization or framework name as a prefix, such as `msft-` or `boost-` to help users find and describe associated libraries.
+
+For example, a library with an official name of `Boost.Asio` might be given the name `boost-asio`.
+
+### <a id="version"></a> `"version"`, `"version-semver"`, `"version-date"`, `"version-string"`
+
+The version of the upstream project. A string. Required for libraries, optional for top-level projects.
+
+A manifest must contain at most one version field. Each version field corresponds to a different versioning _scheme_:
+
+- `"version"` - Relaxed [Semantic Version 2.0.0][], allowing more or less than 3 primary numbers. Example: `1.2.3.4.10-alpha1`
+- `"version-semver"` - Strict [Semantic Version 2.0.0][]. Example: `2.0.1-rc5`
+- `"version-date"` - A date formatted as `YYYY-MM-DD` with an optional trailing dot-separate numeric sequence. Used for packages which do not have numeric releases (for example, Live-at-HEAD). Example: `2022-12-09.314562`
+- `"version-string"` - An arbitrary string. Used for packages that don't have orderable versions. This should be rarely used, however all ports created before the other version fields were introduced use this scheme.
+
+See [versioning](versioning.md#version-schemes) for more details.
+
+[Semantic Version 2.0.0]: https://semver.org/#semantic-versioning-specification-semver
+
+### <a id="port-version"></a> `"port-version"`
+
+A version suffix distinguishing revisions to the packaging files. An integer. Defaults to `0`.
+
+The `"port-version"` should be incremented whenever a new version of the port is published that does not change the upstream source version. When the upstream source version is changed, the [version field](#version) should change and the `"port-version"` should be reset to `0` (or removed).
+
+See [versioning](versioning.md#version-schemes) for more details.
+
+### <a id="description"></a> `"description"`
+
+The description of the port. A string or array of strings. Required for libraries, optional for top-level projects.
+
+This is used to help users discover the library as part of a [`search`](../commands/search.md) or `find` command and learn what the library does.
+
+### <a id="builtin-baseline"></a> `"builtin-baseline"`
+
+A shortcut for specifying the `"baseline"` for version resolution in the default registry. A string. Optional, only used by top-level projects.
+
+This field indicates the commit of https://github.com/microsoft/vcpkg which provides global minimum version information for your manifest. It is required for top-level manifest files using versioning without a specified [`"default-registry"`](vcpkg-configuration-json.md#default-registry). It has the same semantic as defining your default registry to be:
+
+```json
+{
+  "default-registry": {
+    "kind": "builtin",
+    "baseline": "<value>"
+  }
+}
+```
+
+See [versioning](versioning.md#baselines) and [Using registries](registries.md) for more semantic details.
+
+### <a id="dependencies"></a> `"dependencies"`
+
+The list of dependencies required by the project. An array of [Dependency objects][Dependency]. Optional.
+
+This field lists all the dependencies needed to build and use your library or application.
+
+### Example
+
+```json
+"dependencies": [
+  {
+    "name": "arrow",
+    "default-features": false,
+    "features": [ "json" ]
+  },
+  "boost-asio",
+  "openssl",
+  {
+    "name": "picosha2",
+    "platform": "!windows"
+  }
+]
+```
+
+### <a name="overrides"></a> `"overrides"`
+
+Exact version pins to use for specific dependencies. An array of Override objects. Optional.
+
+`"overrides"` from transitive manifests (i.e. from dependencies) are ignored. Only overrides defined by the top-level project are used.
+
+
+| Name | Required | Type   | Description |
+|------|----------|--------|-------------|
+| name | Yes      | string | The port name |
+| version | Yes   | string | The pinned version |
+| port-version | No | integer | The pinned port version |
+
+`"port-version"` can also be specified as a `#N` suffix in the `"version"` field. For example, `1.2.3#7`.
+
+See also [versioning](versioning.md#overrides) for more semantic details.
+
+#### Example
+
+```json
+  "overrides": [
+    {
+      "name": "arrow", "version": "1.2.3", "port-version": 7
+    }
+  ]
+```
+
+### <a name="supports"></a> `"supports"`
+
+Supported platform and build configurations. A [Platform Expression][]. Optional.
+
+This field documents that a project is not expected to build or run successfully on certain platform configurations.
+
+For example, if your library doesn't support building for Linux, you would use `"supports": "!linux"`.
+
+### <a name="features"></a> `"features"`
+
+The [features](manifests.md#features) available for users of the project. A map of names to [Feature objects](#feature). Optional.
+
+Features are boolean flags that add additional behaviors and dependencies to a build. See the [Manifest Concept Documentation](manifests.md#features) for more information about features.
+
+### <a name="default-features"></a> `"default-features"`
+
+The set of features needed for reasonable behavior without additional customization.
+
+The default features are automatically selected if either:
+
+1. A port-to-port dependency for the port has [`"default-features": true`](#dependency-default-features) -- the default value.
+2. The top-level manifest does not have a dependency for the port with [`"default-features": false`](#dependency-default-features).
+
+Default features handle the specific case of providing a "default" configuration for transitive dependencies that the top-level project may not know about. Ports used by others should almost always use `"default-features": false` for their dependencies.
+
+See [`"features"`](#features) for more information about features.
+
+### `"vcpkg-configuration"`
+
+Allows to embed vcpkg configuration properties inside the `vcpkg.json` file. Everything inside the `vcpkg-configuration` property is treated as if it were defined in a `vcpkg-configuration.json` file. For more details, see the [`vcpkg-configuration.json`](registries.md) documentation.
+
+Having a `vcpkg-configuration` defined in `vcpkg.json` while also having a `vcpkg-configuration.json` file is not allowed and will result in the vcpkg command terminating with an error message.
+
+#### Example
+
+```json
+{
+  "name": "test",
+  "version": "1.0.0",
+  "dependencies": [ "beison", "zlib" ],
+  "vcpkg-configuration": {
+    "registries": [
+      {
+        "kind": "git",
+        "baseline": "dacf4de488094a384ca2c202b923ccc097956e0c",
+        "repository": "https://github.com/northwindtraders/vcpkg-registry",
+        "packages": [ "beicode", "beison" ]
+      }
+    ],
+    "overlay-ports": [ "./my-ports/fmt", 
+                       "./team-ports"
+    ]
+  }
+```
+
+## <a name="dependency"></a> Dependency Fields
+
+Each dependency is a string or an object with the following fields:
+
+| Name | Required | Type   | Description |
+|------|----------|--------|-------------|
+| [default-features](#dependency-default-features) | No | bool | Require the features listed as on-by-default |
+| [features](#dependency-features) | No | string[] | The list of additional features to require |
+| [host](#dependency-host) | No | bool | Require the dependency for the host machine instead of the target |
+| [name](#dependency-name) | Yes      | string | The name of the dependency |
+| [platform](#dependency-platform) | No | [Platform Expression][] | Qualifier for which platforms to use the dependency |
+| [version>=](#dependency-version-gt) | No | string | Minimum required version |
+
+Strings are interpreted as an object with _name_ defined to the string value.
+
+[Dependency]: #dependency
+
+### <a name="dependency-default-features"></a> [Dependency][]: `"default-features"`
+
+A boolean indicating that the project depends on the 'on-by-default' features of the dependency. Defaults to `true`.
+
+In most cases, this should be defined to `false` and any needed features should be explicitly depended upon.
+
+### <a name="dependency-features"></a> [Dependency][]: `"features"`
+
+The list of additional features to require. An array of strings. Optional.
+
+For example,
+
+```json
+{
+  "name": "ffmpeg",
+  "default-features": false,
+  "features": [ "mp3lame" ]
+}
+```
+Uses the `ffmpeg` library but only requires mp3 encoding support.
+
+### <a name="dependency-host"></a> [Dependency][]: `"host"`
+
+A boolean indicating that the dependency must be built for the [host triplet](host-dependencies.md) instead of the current port's triplet. Defaults to `false`.
+
+Any dependency that provides tools or scripts which should be "executed" during a build (such as buildsystems, code generators, or helpers) should be marked as `"host": true`. This enables correct cross-compilation in cases that the target is not executable -- such as when compiling for `arm64-android`.
+
+See [Host dependencies](host-dependencies.md) for more information.
+
+### <a name="dependency-name"></a> [Dependency][]: `"name"`
+
+The name of the dependency. A string. Required.
+
+This follows the same restrictions as the [`"name"`](#name) property for a project.
+
+### <a name="dependency-platform"></a> [Dependency][]: `"platform"`
+
+An expression that limits the platforms where the dependency is required. A [Platform Expression][]. Optional.
+
+If the expression does not match the current configuration, the dependency will not be used. For example, if a dependency has `"platform": "!windows"`, it only be required when targeting non-Windows systems.
+
+### <a name="dependency-version-gt"></a> [Dependency][]: `"version>="`
+
+A minimum version constraint on the dependency.
+
+This field specifies the minimum version of the dependency, optionally using a
+`#N` suffix to denote port-version if non-zero.
+
+For more information on versioning semantics, see [Versioning](versioning.md#version).
+
+## <a name="feature"></a> Feature Fields
+
+Each feature is an object with the following fields:
+
+| Name | Required | Type   | Description |
+|------|----------|--------|-------------|
+| [description](#feature-description) | Yes      | string | The description of the feature |
+| [dependencies](#feature-dependencies) | No | [Dependency][][] | A list of dependencies |
+| [supports](#feature-supports) | No | [Platform Expression][] | Qualifier for which platforms and configurations the feature supports |
+
+Check out the [Manifest mode](manifests.md#features) documentation for a conceptual overview of features.
+
+[Feature]: #feature
+
+### Example
+
+```json
+{
+  "features": {
+    "cbor": {
+      "description": "The CBOR backend",
+      "dependencies": [
+        {
+          "$explanation": [
+            "This is how you tell vcpkg that the cbor feature depends on the json feature of this package"
+          ],
+          "name": "libdb",
+          "default-features": false,
+          "features": [ "json" ]
+        }
+      ]
+    },
+    "csv": {
+      "description": "The CSV backend",
+      "dependencies": [
+        "fast-cpp-csv-parser"
+      ]
+    },
+    "json": {
+      "description": "The JSON backend",
+      "dependencies": [
+        "jsoncons"
+      ]
+    }
+  }
+}
+```
+
+### <a id="feature-dependencies"></a> [Feature][]: `"dependencies"`
+
+The list of dependencies required by the [feature](manifests.md#features). An array of [Dependency objects][Dependency]. Optional.
+
+This field lists any additional dependencies needed to build and use the feature.
+
+### <a id="feature-description"></a> [Feature][]: `"description"`
+
+The description of the [feature](manifests.md#features). A string or array of strings. Required.
+
+This is used to help users discover the feature as part of a [`search`](../commands/search.md) or `find` command and learn what the feature does.
+
+### <a name="feature-supports"></a> [Feature][]: `"supports"`
+
+The supported platform and build configurations for the [feature](manifests.md#features). A [Platform Expression][]. Optional.
+
+This field documents the platform configurations where the feature will build and run successfully.
+
+## <a name="platform-expression"></a> Platform Expression
+
+A Platform Expression is a JSON string which describes when a dependency is required or when a library or feature is expected to build.
+
+Expressions are built from primitive identifiers, logical operators, and grouping:
+
+- `!<expr>`, `not <expr>` - negation
+- `<expr>|<expr>`, `<expr>||<expr>`, `<expr>,<expr>`, `<expr> or <expr>` - logical OR
+- `<expr>&<expr>`, `<expr>&&<expr>`, `<expr> and <expr>` - logical AND
+- `(<expr>)` - grouping/precedence
+
+The following identifiers are defined based on the [triplet settings](triplets.md) and build configuration:
+
+| Identifier | Triplet Condition |
+|------------|-------------------|
+| `x64` | `VCPKG_TARGET_ARCHITECTURE` == `"x64"` |
+| `x86` | `VCPKG_TARGET_ARCHITECTURE` == `"x86"` |
+| `arm` | `VCPKG_TARGET_ARCHITECTURE` == `"arm"` or</br> `VCPKG_TARGET_ARCHITECTURE` == `"arm64"` |
+| `arm64` | `VCPKG_TARGET_ARCHITECTURE` == `"arm64"` |
+| `wasm32` | `VCPKG_TARGET_ARCHITECTURE` == `"wasm32"` |
+| `windows` | `VCPKG_CMAKE_SYSTEM_NAME` == `""` or</br> `VCPKG_CMAKE_SYSTEM_NAME` == `"WindowsStore"` or</br> `VCPKG_CMAKE_SYSTEM_NAME` == `"MinGW"` |
+| `mingw` | `VCPKG_CMAKE_SYSTEM_NAME` == `"MinGW"` |
+| `uwp` | `VCPKG_CMAKE_SYSTEM_NAME` == `"WindowsStore"` |
+| `linux` | `VCPKG_CMAKE_SYSTEM_NAME` == `"Linux"` |
+| `osx` | `VCPKG_CMAKE_SYSTEM_NAME` == `"Darwin"` |
+| `ios` | `VCPKG_CMAKE_SYSTEM_NAME` == `"iOS"` |
+| `freebsd` | `VCPKG_CMAKE_SYSTEM_NAME` == `"FreeBSD"` |
+| `openbsd` | `VCPKG_CMAKE_SYSTEM_NAME` == `"OpenBSD"` |
+| `android` | `VCPKG_CMAKE_SYSTEM_NAME` == `"Android"` |
+| `emscripten` | `VCPKG_CMAKE_SYSTEM_NAME` == `"Emscripten"` |
+| `static` | `VCPKG_LIBRARY_LINKAGE` == `"static"` |
+| `static-crt` | `VCPKG_CRT_LINKAGE` == `"static"` |
+| `native` | `TARGET_TRIPLET` == `HOST_TRIPLET` |
+
+### Examples
+
+- **Needs `picosha2` for sha256 on non-Windows, but get it from the OS on Windows (BCrypt)**
+
+```jsonc
+{
+  "name": "picosha2",
+  "platform": "!windows"
+}
+```
+
+- **Require zlib on arm64 Windows and amd64 Linux**
+
+```jsonc
+{
+  "name": "zlib",
+  "platform": "(windows & arm64) | (linux & x64)"
+}
+```
+
+[Platform Expression]: #platform-expression

--- a/vcpkg/users/versioning.md
+++ b/vcpkg/users/versioning.md
@@ -5,8 +5,7 @@ ms.date: 11/30/2022
 ---
 # Versioning reference
 
-Versioning allows you to deterministically control the precise revisions of dependencies used by
-your project from within your manifest file. Versioning only applies to [Manifest mode](manifests.md).
+Versioning allows you to deterministically control the precise revisions of dependencies used by your project from within your manifest file. Versioning only applies to [Manifest mode](manifests.md).
 
 For more information about the vcpkg versioning algorithm and high level concepts, see [Versioning Concepts](versioning.concepts.md).
 
@@ -32,12 +31,12 @@ Each versioning scheme defines its own rules on what is a valid version string a
 
 The versioning schemes understood by vcpkg are:
 
-| Manifest property | Versioning scheme |
-|---|---|
-| `version` | For dot-separated numeric versions |
-| `version-semver` | For SemVer compliant versions |
-| `version-date` | For dates in the format YYYY-MM-DD |
-| `version-string` | For arbitrary strings |
+| Manifest property | Versioning scheme                    |
+|-------------------|--------------------------------------|
+| `version`         | For dot-separated numeric versions   |
+| `version-semver`  | For SemVer compliant versions        |
+| `version-date`    | For dates in the format `YYYY-MM-DD` |
+| `version-string`  | For arbitrary strings                |
 
 A manifest must contain only one version declaration.
 
@@ -119,7 +118,7 @@ Examples:
 
 Baselines define a global version floor for what versions will be considered. This enables top-level manifests to keep the entire graph of dependencies up-to-date without needing to individually specify direct [`"version>="`](#version-gte) constraints.
 
-Every configured registry has an associated baseline. For manifests that don't configure any registries, the [`"builtin-baseline"`](manifests.md#builtin-baseline) field defines the baseline for the built-in registry. If a manifest does not configure any registries and does not have a `"builtin-baseline"`, the install operates according to the Classic mode algorithm and ignores all versioning information.
+Every configured registry has an associated baseline. For manifests that don't configure any registries, the [`"builtin-baseline"`](vcpkg-json.md#builtin-baseline) field defines the baseline for the built-in registry. If a manifest does not configure any registries and does not have a `"builtin-baseline"`, the install operates according to the Classic mode algorithm and ignores all versioning information.
 
 Baselines, like other registry settings, are ignored from ports consumed as a dependency. If a minimum version is required during transitive version resolution the port should use [`"version>="`](#version-gte).
 


### PR DESCRIPTION
See a preview at https://review.learn.microsoft.com/en-us/vcpkg/users/vcpkg-json?branch=dev%2Froschuma%2Fmain

I've heavily rewritten these files, so I recommend instead reading them 'cover to cover' as though they were new documents:

- https://review.learn.microsoft.com/vcpkg/users/vcpkg-configuration-json?branch=dev%2Froschuma%2Fmain
- https://review.learn.microsoft.com/vcpkg/users/vcpkg-json?branch=dev%2Froschuma%2Fmain
- https://review.learn.microsoft.com/vcpkg/users/manifests?branch=dev%2Froschuma%2Fmain
- https://review.learn.microsoft.com/vcpkg/users/registries?branch=dev%2Froschuma%2Fmain