### PR TITLE
Adding a dev container specification

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+{
+	"name": "vcpkg-docs Container",
+	"image": "mcr.microsoft.com/devcontainers/base:alpine-3.17",
+
+	"customizations": {
+      "vscode": {
+        "extensions": ["docsmsft.docs-authoring-pack"]
+      }
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,8 @@
 	"image": "mcr.microsoft.com/devcontainers/base:alpine-3.17",
 
 	"customizations": {
-      "vscode": {
-        "extensions": ["docsmsft.docs-authoring-pack"]
-      }
+		"vscode": {
+			"extensions": ["docsmsft.docs-authoring-pack"]
+		}
 	}
 }


### PR DESCRIPTION
This should make it marginally easier for contributors.

This dev container specification will install the Learn Authoring Pack for VSCode in the container when connecting to the container from VS Code.

See https://learn.microsoft.com/en-us/contribute/how-to-write-docs-auth-pack