### PR TITLE
add host-dependencies

### DIFF
--- a/vcpkg/TOC.yml
+++ b/vcpkg/TOC.yml
@@ -67,6 +67,9 @@
   - name: Authoring Script Ports
     displayName: helpers, scripts, reuseable, function, reuse
     href: maintainers/authoring-script-ports.md
+  - name: Host Dependencies
+    displayName: host, dependencies
+    href: users/host-dependencies
   - name: Creating Registries
     href: maintainers/registries.md
   - name: Portfile Variable Reference

--- a/vcpkg/TOC.yml
+++ b/vcpkg/TOC.yml
@@ -69,7 +69,7 @@
     href: maintainers/authoring-script-ports.md
   - name: Host Dependencies
     displayName: host, dependencies
-    href: users/host-dependencies
+    href: users/host-dependencies.md
   - name: Creating Registries
     href: maintainers/registries.md
   - name: Portfile Variable Reference

--- a/vcpkg/TOC.yml
+++ b/vcpkg/TOC.yml
@@ -67,11 +67,11 @@
   - name: Authoring Script Ports
     displayName: helpers, scripts, reuseable, function, reuse
     href: maintainers/authoring-script-ports.md
+  - name: Creating Registries
+    href: maintainers/registries.md
   - name: Host Dependencies
     displayName: host, dependencies
     href: users/host-dependencies.md
-  - name: Creating Registries
-    href: maintainers/registries.md
   - name: Portfile Variable Reference
     href: maintainers/variables.md
   - name: Portfile Function Reference


### PR DESCRIPTION
The "Host Dependencies" page is missing from the tree view. 