### PR TITLE
Migrate Microsoft/vcpkg#27467

### DIFF
--- a/vcpkg/users/config-environment.md
+++ b/vcpkg/users/config-environment.md
@@ -107,3 +107,10 @@ This environment variable allows using a private mirror for all SHA512-tagged as
 Setting `VCPKG_NO_CI` disables vcpkg's CI environment detection heuristics.
 
 [Binary Caching]: binarycaching.md
+
+## VSLANG
+
+This environment variable sets the language vcpkg uses to display messages. It should be set to one of the 14 supported LCIDs (locale identifier, 4-byte value corresponding to a language). 
+
+For example: 1033 corresponds to the English (US) language. 
+For a full list of supported LCIDs see [Localization](https://github.com/microsoft/vcpkg-tool/blob/main/docs/localization.md).

--- a/vcpkg/users/config-environment.md
+++ b/vcpkg/users/config-environment.md
@@ -1,7 +1,7 @@
 ---
 title: Environment variables
 description: Use environment variables to control how vcpkg works and where it looks for files.
-ms.date: 11/30/2022
+ms.date: 2/10/2023
 ---
 # Environment variables
 


### PR DESCRIPTION
`microsoft/vcpkg-docs` is an independent `vcpkg` document repository, so migrate https://github.com/microsoft/vcpkg/pull/27467 into `microsoft/vcpkg-docs`.