### PR TITLE
Added windows and uwp platform topic pages

### DIFF
--- a/vcpkg/examples/patching.md
+++ b/vcpkg/examples/patching.md
@@ -65,7 +65,7 @@ Time Elapsed 00:00:04.19
 
 ## Identify the problematic code
 
-Taking a look at [MSDN](https://msdn.microsoft.com/library/windows/desktop/ms682658(v=vs.85).aspx) shows that `ExitProcess` is only available for desktop apps. Additionally, it's useful to see the surrounding context:
+Taking a look at [Microsoft Learn](/windows/win32/api/processthreadsapi/nf-processthreadsapi-exitprocess) shows that `ExitProcess` is only available for desktop apps. Additionally, it's useful to see the surrounding context:
 
 ```c
 /* buildtrees\libpng\src\v1.6.37-c993153cdf\pngerror.c:769 */

--- a/vcpkg/users/platforms/uwp.md
+++ b/vcpkg/users/platforms/uwp.md
@@ -9,20 +9,16 @@ ms.date: 04/28/2023
 
 vcpkg includes [triplets](https://github.com/microsoft/vcpkg/tree/master/triplets) for building UWP applications using the MSVC ``cl.exe`` compiler.
 
-| Architecture | vcpkg triplets |
-|--------------|----------------|
-| x64          | x64-uwp        |
-| arm          | arm-uwp        |
-
-There are also additional [community triplets](https://github.com/microsoft/vcpkg/tree/master/triplets/community) for UWP as well.
-
-| Architecture | vcpkg community triplets |
-|--------------|--------------------------|
-| x86          | x86-uwp                  | 
-| arm64        | arm64-uwp                |
-
-> [!NOTE]
-> Community triplets are not tested as part of vcpkg repository's CI process, so regressions can occur as part of library updates. PRs improving support are welcome!
+| Architecture | vcpkg triplets      | Community |
+|--------------|---------------------|-----------|
+| x64          | x64-uwp             |           |
+|              | x64-uwp-static-md   | Yes       |
+| x86          | x86-uwp             | Yes       |
+|              | x86-uwp-static-md   | Yes       |
+| arm          | arm-uwp             |           |
+|              | arm-uwp-static-md   | Yes       |
+| arm64        | arm64-uwp           | Yes       |
+|              | arm64-uwp-static-md | Yes       |
 
 ## C++/CX vs. C++/WinRT projections
 
@@ -32,9 +28,9 @@ The UWP triplet toolchain leaves enabling C++/CX (``/ZW``) up to CMake, but does
 
 ## Maintainer notes
 
-CMake projects for these triplets are built using ``CMAKE_SYSTEM_NAME`` set to "WindowsStore" and ``CMAKE_SYSTEM_VERSION`` set to "10.0"
+CMake projects for these triplets are built using `CMAKE_SYSTEM_NAME` set to "WindowsStore" and `CMAKE_SYSTEM_VERSION` set to "10.0"
 
-For CMake 3.1 or later, you control the enabling of the MSVC C++/CX language extensions via the ``VS_WINRT_COMPONENT`` property for the *Visual Studio generator*.
+For CMake 3.1 or later, you control the enabling of the MSVC C++/CX language extensions via the `VS_WINRT_COMPONENT` property for the *Visual Studio generator*.
 
 The UWP triplets also build code using ``/DWINAPI_FAMILY=WINAPI_FAMILY_APP`` for the API partition, so libraries can fail to build if they are using unsupported versions of Win32 APIs. The general recommendation is to use the newer APIs in all cases, but if you need to build the same library for older versions of the Windows OS then you may need to use conditionally building code such as the following to support both scenarios.
 
@@ -56,6 +52,8 @@ The UWP triplets also build code using ``/DWINAPI_FAMILY=WINAPI_FAMILY_APP`` for
 ```
 
 UWP triplets also build with ``/DUNICODE /D_UNICODE`` as these are both strongly recommended for modern development. See the [UTF-8 Everywhere manifesto](https://utf8everywhere.org/) for more information.
+
+## Library author notes
 
 If using CMake for your library, consider using something similiar to the following:
 

--- a/vcpkg/users/platforms/uwp.md
+++ b/vcpkg/users/platforms/uwp.md
@@ -1,0 +1,76 @@
+---
+title: Universal Windows Platform
+description: Building for UWP with the Microsoft Visual C++ Compiler
+ms.date: 04/28/2023
+---
+# Universal Windows Platform (UWP)
+
+## Triplets
+
+vcpkg includes [triplets](https://github.com/microsoft/vcpkg/tree/master/triplets) for building UWP applications using the MSVC ``cl.exe`` compiler.
+
+| Architecture | vcpkg triplets |
+|--------------|----------------|
+| x64          | x64-uwp        |
+| arm          | arm-uwp        |
+
+There are also additional [community triplets](https://github.com/microsoft/vcpkg/tree/master/triplets/community) for UWP as well.
+
+| Architecture | vcpkg community triplets |
+|--------------|--------------------------|
+| x86          | x86-uwp                  | 
+| arm64        | arm64-uwp                |
+
+> [!NOTE]
+> Community triplets are not tested as part of vcpkg repository's CI process, so regressions can occur as part of library updates. PRs improving support are welcome!
+
+## C++/CX vs. C++/WinRT projections
+
+UWP applications typically consume Windows Runtime APIs, and there are a number of solutions for using these from C++. The [C++/CX language extensions](/cpp/cppcx/visual-c-language-reference-c-cx) for the MSVC compiler (``/ZW``), the [C++/WinRT language projections](/windows/uwp/cpp-and-winrt-apis/) which works with C++17 compilers, or the [Windows Runtime Library](/cpp/cppcx/wrl/windows-runtime-cpp-template-library-wrl).
+
+The UWP triplet toolchain leaves enabling C++/CX (``/ZW``) up to CMake, but does provide a ``/FU`` parameter to point to the proper ``platform.winmd`` file for the toolset being used.
+
+## Maintainer notes
+
+CMake projects for these triplets are built using ``CMAKE_SYSTEM_NAME`` set to "WindowsStore" and ``CMAKE_SYSTEM_VERSION`` set to "10.0"
+
+For CMake 3.1 or later, you control the enabling of the MSVC C++/CX language extensions via the ``VS_WINRT_COMPONENT`` property for the *Visual Studio generator*.
+
+The UWP triplets also build code using ``/DWINAPI_FAMILY=WINAPI_FAMILY_APP`` for the API partition, so libraries can fail to build if they are using unsupported versions of Win32 APIs. The general recommendation is to use the newer APIs in all cases, but if you need to build the same library for older versions of the Windows OS then you may need to use conditionally building code such as the following to support both scenarios.
+
+```
+    HANDLE hFile = nullptr;
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+    hFile = CreateFile2(
+                fileName,
+                GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
+                nullptr);
+#else
+    hFile = CreateFileW(
+                fileName,
+                GENERIC_READ, FILE_SHARE_READ,
+                nullptr,
+                OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+                nullptr);
+#endif
+```
+
+UWP triplets also build with ``/DUNICODE /D_UNICODE`` as these are both strongly recommended for modern development. See the [UTF-8 Everywhere manifesto](https://utf8everywhere.org/) for more information.
+
+If using CMake for your library, consider using something similiar to the following:
+
+```
+target_compile_definitions(${PROJECT_NAME} PRIVATE _UNICODE UNICODE)
+
+if(WINDOWS_STORE)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC WINAPI_FAMILY=WINAPI_FAMILY_APP)
+endif()
+```
+
+You should set `` _WIN32_WINNT=0x0A00`` as well for either all ``WIN32`` platforms, or at least  for ``WINDOWS_STORE`` platform builds.
+
+## Further reading
+
+[Get started with Windows apps](/windows/uwp/get-started/)
+
+[UWP on Xbox One](/windows/uwp/xbox-apps/)

--- a/vcpkg/users/platforms/windows.md
+++ b/vcpkg/users/platforms/windows.md
@@ -36,6 +36,131 @@ The ``static`` linking triplets are set to use the MSVC Runtime as a static libr
 
 The ``static-md`` linking triplets are set to use the MSVC Runtime as a DLL (i.e. ``VCPKG_CRT_LINKAGE dynamic``). This is the recommended solution for redistributing the MSVC Runtime per [Microsoft Learn](/cpp/windows/deployment-in-visual-cpp).
 
+## Selecting a Visual C++ Toolset
+
+By default, vcpkg will use the latest version of Visual Studio installed on the system for building code. To select a specific version, create a custom triplet or triplet overlay to set it.
+
+For examples, this would force the use of the VS 2017 toolset.
+
+```
+set(VCPKG_PLATFORM_TOOLSET v141)
+```
+
+See [Triplet files](../triplets) for more information.
+
+## C/C++ Runtime
+
+Keep in mind that the Microsoft Visual C/C++ Runtime is 'forward binary compatible'. This means you can build code with VS 2015 Update 3, VS 2017, VS 2019, and/or VS 2022 and link it all together. The key requirement is that the LINK must be done against the *newest* toolset in the mix. See [Microsoft Learn](/cpp/porting/binary-compat-2015-2017).
+
+## Known issues
+
+* If you get the following link failure, it is because you are building x64 native code with VS 2019 or later, but linking it with the VS 2017 toolset & CRT combination. Per the notes above, you should use the newest compiler toolset for your final link. This *specific* issue can be worked around as well with ``/d2FH4-`` (v142 or later) to use the older x64 C++ exception implementation.
+
+```
+error LNK2001: unresolved external symbol ___CxxFrameHandler4
+```
+
+See the [Visual C++ Team Blog](https://devblogs.microsoft.com/cppblog/making-cpp-exception-handling-smaller-x64/) for more information.
+
+* Full C++20 support requires VS 2019 (16.11.14 or later) and/or VS 2022 (17.2 or later). See the [Visual C++ Team Blog](https://devblogs.microsoft.com/cppblog/msvc-cpp20-and-the-std-cpp20-switch/).
+
 ## Maintainer notes
 
 CMake projects for these triplets are built using ``CMAKE_SYSTEM_NAME`` set to "Windows".
+
+* "Just My Code" debugging can usually be disabled in a library to save code space.
+
+```
+if(MSVC)
+    target_compile_options(mytarget PRIVATE /JMC-)
+endif()
+```
+
+* MSBuild will automatically add some build flags that are not on-by-default in the MSVC compiler itself. To ensure the same behavior with Ninja or other generators, add these build settings.
+
+```
+if(MSVC)
+    target_compile_options(mytarget PRIVATE /Zc:inline)
+endif()
+```
+
+* Recommended build settings for newer versions of Visual C++ are encouraged for improved code security.
+
+```
+if(MSVC)
+    target_compile_options(mytarget PRIVATE "$<$<NOT:$<CONFIG:DEBUG>>:/guard:cf>")
+    target_link_options(mytarget PRIVATE /DYNAMICBASE /NXCOMPAT)
+
+    if((CMAKE_SIZEOF_VOID_P EQUAL 4)
+       AND (NOT (${VCPKG_TARGET_ARCHITECTURE} MATCHES "^arm")))
+      target_link_options(mytarget PRIVATE /SAFESEH)
+    endif()
+
+    if((MSVC_VERSION GREATER_EQUAL 1928)
+       AND (CMAKE_SIZEOF_VOID_P EQUAL 8)
+       AND ((NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+            OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)))
+      target_compile_options(mytarget PRIVATE "$<$<NOT:$<CONFIG:DEBUG>>:/guard:ehcont>")
+      target_link_options(mytarget PRIVATE "$<$<NOT:$<CONFIG:DEBUG>>:/guard:ehcont>")
+    endif()
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(mytarget PRIVATE /sdl)
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
+        target_compile_options(mytarget PRIVATE /ZH:SHA_256)
+    endif()
+
+    if((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.27)
+       AND (NOT (${VCPKG_TARGET_ARCHITECTURE} MATCHES "^arm")))
+        target_link_options(mytarget PRIVATE /CETCOMPAT)
+    endif()
+endif()
+```
+
+* For improved Standard C/C++ Conformance, use the latest switch settings.
+
+```
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(mytarget PRIVATE /permissive- /Zc:__cplusplus /Zc:inline)
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.26)
+        target_compile_options(mytarget PRIVATE /Zc:preprocessor)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.28)
+        target_compile_options(mytarget PRIVATE /Zc:lambda)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
+        target_compile_options(mytarget PRIVATE /Zc:templateScope)
+    endif()
+endif()
+```
+
+* To support the use of Whole Program Optimization / Link-Time Code Generation, recommended build settings are as follows:
+
+```
+if((CMAKE_CXX_COMPILER_ID MATCHES "MSVC") AND CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+    target_compile_options(${PROJECT_NAME} PRIVATE /Gy /Gw)
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
+        target_compile_options(mytarget PRIVATE /Zc:checkGwOdr)
+    endif()
+endif()
+```
+
+* If enabling Spectre migations, use the following guards.
+
+```
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    if((MSVC_VERSION GREATER_EQUAL 1913) AND (NOT WINDOWS_STORE))
+      target_compile_options(mytarget PRIVATE "/Qspectre")
+    endif()
+endif()
+```
+
+Note you may want to also provide an explicit CMake build option to control this as well.
+
+See [Microsoft Learn](cpp/build/reference/qspectre).

--- a/vcpkg/users/platforms/windows.md
+++ b/vcpkg/users/platforms/windows.md
@@ -9,28 +9,23 @@ ms.date: 04/28/2023
 
 vcpkg includes [triplets](https://github.com/microsoft/vcpkg/tree/master/triplets) for building Windows desktop applications using the MSVC ``cl.exe`` compiler.
 
-| Architecture | vcpkg triplets     |
-|--------------|--------------------|
-| x64          | x64-windows        |
-|              | x64-windows-static |
-| x86          | x86-windows        |
-| arm64        | arm64-windows      |
-
-There are also a number of [community triplets](https://github.com/microsoft/vcpkg/tree/master/triplets/community) for the MSVC compiler toolset as well.
-
-| Architecture | vcpkg community triplets |
-|--------------|--------------------------|
-| x64          | x64-windows-static-md    |
-| x86          | x86-windows-static       |
-|              | x86-windows-static-md    |
-| arm          | arm-windows              |
-|              | arm-windows-static       |
-| arm64        | arm64-windows-static     |
-|              | arm64-windows-static-md  |
-|              | arm64ec-windows          |
-
-> [!NOTE]
-> Community triplets are not tested as part of vcpkg repository's CI process, so regressions can occur as part of library updates. PRs improving support are welcome!
+| Architecture | vcpkg triplets               | Community |
+|--------------|------------------------------|-----------|
+| x64          | x64-windows                  |           |
+|              | x64-windows-release          | Yes       |
+|              | x64-windows-static           |           |
+|              | x64-windows-static-md        | Yes       |
+|              | x64-windows-static-release   | Yes       |
+| x86          | x86-windows                  |           |
+|              | x86-windows-static           | Yes       |
+|              | x86-windows-static-md        | Yes       |
+| arm          | arm-windows                  | Yes       |
+|              | arm-windows-static           | Yes       |
+| arm64        | arm64-windows                |           |
+|              | arm64-windows-static         | Yes       |
+|              | arm64-windows-static-md      | Yes       |
+|              | arm64-windows-static-release | Yes       |
+| arm64ec      | arm64ec-windows              | Yes       |
 
 The ``static`` linking triplets are set to use the MSVC Runtime as a static library (i.e. ``VCPKG_CRT_LINKAGE static``).
 
@@ -38,7 +33,7 @@ The ``static-md`` linking triplets are set to use the MSVC Runtime as a DLL (i.e
 
 ## Selecting a Visual C++ Toolset
 
-By default, vcpkg will use the latest version of Visual Studio installed on the system for building code. To select a specific version, create a custom triplet or triplet overlay to set it.
+By default, vcpkg will use the latest version of Visual Studio installed on the system for building code. To select a specific version, create a custom triplet or triplet overlay to set [`VCPKG_PLATFORM_TOOLSET`](../triplets.md#vcpkg_platform_toolset).
 
 For examples, this would force the use of the VS 2017 toolset.
 
@@ -46,27 +41,15 @@ For examples, this would force the use of the VS 2017 toolset.
 set(VCPKG_PLATFORM_TOOLSET v141)
 ```
 
-See [Triplet files](../triplets.md) for more information.
+## C/C++ Runtime Compatibility
 
-## C/C++ Runtime
-
-Keep in mind that the Microsoft Visual C/C++ Runtime is 'forward binary compatible'. This means you can build code with VS 2015 Update 3, VS 2017, VS 2019, and/or VS 2022 and link it all together. The key requirement is that the LINK must be done against the *newest* toolset in the mix. See [Microsoft Learn](/cpp/porting/binary-compat-2015-2017).
-
-## Known issues
-
-* If you get the following link failure, it is because you are building x64 native code with VS 2019 or later, but linking it with the VS 2017 toolset & CRT combination. Per the notes above, you should use the newest compiler toolset for your final link. This *specific* issue can be worked around as well with ``/d2FH4-`` (v142 or later) to use the older x64 C++ exception implementation.
-
-```
-error LNK2001: unresolved external symbol ___CxxFrameHandler4
-```
-
-See the [Visual C++ Team Blog](https://devblogs.microsoft.com/cppblog/making-cpp-exception-handling-smaller-x64/) for more information.
-
-* Full C++20 support requires VS 2019 (16.11.14 or later) and/or VS 2022 (17.2 or later). See the [Visual C++ Team Blog](https://devblogs.microsoft.com/cppblog/msvc-cpp20-and-the-std-cpp20-switch/).
+The Microsoft Visual C/C++ Runtime is 'forward binary compatible'. This means you can build code with VS 2015 Update 3, VS 2017, VS 2019, and/or VS 2022 and link it all together. The key requirement is that the LINK must be done against the *newest* toolset in the mix. See [Microsoft Learn](/cpp/porting/binary-compat-2015-2017).
 
 ## Maintainer notes
 
-CMake projects for these triplets are built using ``CMAKE_SYSTEM_NAME`` set to "Windows".
+CMake projects for these triplets are built using `CMAKE_SYSTEM_NAME` set to "Windows".
+
+## Library author notes
 
 * "Just My Code" debugging can usually be disabled in a library to save code space.
 

--- a/vcpkg/users/platforms/windows.md
+++ b/vcpkg/users/platforms/windows.md
@@ -46,7 +46,7 @@ For examples, this would force the use of the VS 2017 toolset.
 set(VCPKG_PLATFORM_TOOLSET v141)
 ```
 
-See [Triplet files](../triplets) for more information.
+See [Triplet files](../triplets.md) for more information.
 
 ## C/C++ Runtime
 
@@ -163,4 +163,4 @@ endif()
 
 Note you may want to also provide an explicit CMake build option to control this as well.
 
-See [Microsoft Learn](cpp/build/reference/qspectre).
+See [Microsoft Learn](/cpp/build/reference/qspectre).

--- a/vcpkg/users/platforms/windows.md
+++ b/vcpkg/users/platforms/windows.md
@@ -134,7 +134,7 @@ if((CMAKE_CXX_COMPILER_ID MATCHES "MSVC") AND CMAKE_INTERPROCEDURAL_OPTIMIZATION
 endif()
 ```
 
-* If enabling Spectre migations, use the following guards.
+* If enabling Spectre mitigations, use the following guards.
 
 ```
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")

--- a/vcpkg/users/platforms/windows.md
+++ b/vcpkg/users/platforms/windows.md
@@ -1,0 +1,41 @@
+---
+title: Microsoft Visual C++ for Windows
+description: Building for Windows with the Microsoft Visual C++ Compiler
+ms.date: 04/28/2023
+---
+# Microsoft Visual C++
+
+## Triplets
+
+vcpkg includes [triplets](https://github.com/microsoft/vcpkg/tree/master/triplets) for building Windows desktop applications using the MSVC ``cl.exe`` compiler.
+
+| Architecture | vcpkg triplets     |
+|--------------|--------------------|
+| x64          | x64-windows        |
+|              | x64-windows-static |
+| x86          | x86-windows        |
+| arm64        | arm64-windows      |
+
+There are also a number of [community triplets](https://github.com/microsoft/vcpkg/tree/master/triplets/community) for the MSVC compiler toolset as well.
+
+| Architecture | vcpkg community triplets |
+|--------------|--------------------------|
+| x64          | x64-windows-static-md    |
+| x86          | x86-windows-static       |
+|              | x86-windows-static-md    |
+| arm          | arm-windows              |
+|              | arm-windows-static       |
+| arm64        | arm64-windows-static     |
+|              | arm64-windows-static-md  |
+|              | arm64ec-windows          |
+
+> [!NOTE]
+> Community triplets are not tested as part of vcpkg repository's CI process, so regressions can occur as part of library updates. PRs improving support are welcome!
+
+The ``static`` linking triplets are set to use the MSVC Runtime as a static library (i.e. ``VCPKG_CRT_LINKAGE static``).
+
+The ``static-md`` linking triplets are set to use the MSVC Runtime as a DLL (i.e. ``VCPKG_CRT_LINKAGE dynamic``). This is the recommended solution for redistributing the MSVC Runtime per [Microsoft Learn](/cpp/windows/deployment-in-visual-cpp).
+
+## Maintainer notes
+
+CMake projects for these triplets are built using ``CMAKE_SYSTEM_NAME`` set to "Windows".


### PR DESCRIPTION
The basic windows and uwp triplets are not documented currently except implicitly through other pages.  This updates the docs to include specific subpages for these important platforms with relevant information.