### PR TITLE
Fix usage section title

### DIFF
--- a/vcpkg/TOC.yml
+++ b/vcpkg/TOC.yml
@@ -232,7 +232,7 @@
         href: maintainers/functions/internal/z_vcpkg_restore_pkgconfig_path.md
       - name: z_vcpkg_setup_pkgconfig_path
         href: maintainers/functions/internal/z_vcpkg_setup_pkgconfig_path.md
-  - name: Provide usage documentation for your packages
+  - name: Provide Usage Documentation
     href: maintainers/handling-usage-files.md
   - name: CONTROL Files (deprecated)
     href: maintainers/control-files.md

--- a/vcpkg/maintainers/handling-usage-files.md
+++ b/vcpkg/maintainers/handling-usage-files.md
@@ -1,5 +1,5 @@
 ---
-title: Provide usage documentation for your ports
+title: Provide Usage Documentation
 description: Guidance for adding usage documentation to vcpkg ports
 author: JavierMatosD
 ms.author: javiermat

--- a/vcpkg/maintainers/handling-usage-files.md
+++ b/vcpkg/maintainers/handling-usage-files.md
@@ -6,7 +6,7 @@ ms.author: javiermat
 ms.date: 07/17/2023
 ms.prod: vcpkg
 ---
-# Provide usage documentation for your ports
+# Provide Usage Documentation
 
 ## Overview
 

--- a/vcpkg/maintainers/handling-usage-files.md
+++ b/vcpkg/maintainers/handling-usage-files.md
@@ -30,7 +30,7 @@ After installing ports, vcpkg detects files installed to `${CURRENT_PACKAGES_DIR
 
 ### Content format
 
-Provide clear instructions on how to use the package. The content should be concise, well-structured, and emphasize the minimum build system integration required to use the library.
+Provide clear instructions on how to use the package. The content should be concise, well-structured, and emphasize the minimum build system integration required to use the library. Usage is intended to be useful to all downstream customers of a library, not a subset of those users.
 
 Be clear and concise about how to utilize the package effectively. Avoid overwhelming users with code snippets, command-line instructions, or configuration details. Instead, use the [`"documentation"` property in the port's `vcpkg.json` file](../users/manifests.md) so users can learn more about your library.
 


### PR DESCRIPTION
Currently, the usage title looks like this:

![image](https://github.com/microsoft/vcpkg-docs/assets/44559473/508c285c-b790-4a0f-afd9-2e8d7c77d267)

All the other titles are capitalized, so this just looks odd. The current title is also pretty long :/

Additionally, I added some extra clarification for "minimum build system integration."
