### PR TITLE
Document "Reference/Commands/vcpkg contact"

### DIFF
--- a/vcpkg/TOC.yml
+++ b/vcpkg/TOC.yml
@@ -246,6 +246,8 @@
       items:
         - name: Common Command Options
           href: commands/common-options.md
+        - name: vcpkg contact
+          href: commands/contact.md
         - name: vcpkg depend-info
           href: commands/depend-info.md
         - name: vcpkg export

--- a/vcpkg/commands/contact.md
+++ b/vcpkg/commands/contact.md
@@ -1,0 +1,32 @@
+---
+title: vcpkg contact
+description: Reference for the vcpkg contact command. Provides an official contact (vcpkg@microsoft.com)
+author: JavierMatosD
+ms.author: javiermat
+ms.date: 08/15/2023
+ms.prod: vcpkg
+---
+# vcpkg contact
+
+## Synopsis
+
+```console
+vcpkg contact
+```
+
+## Description
+
+Provides users with an email address to reach out to the vcpkg team for support or inquiries.
+
+## Example
+
+```console
+$ vcpkg contact
+
+Send an email to vcpkg@microsoft.com with any feedback.
+```
+
+## Options
+
+All vcpkg commands support a set of [common options](common-options.md).
+

--- a/vcpkg/commands/contact.md
+++ b/vcpkg/commands/contact.md
@@ -30,3 +30,10 @@ Send an email to vcpkg@microsoft.com with any feedback.
 
 All vcpkg commands support a set of [common options](common-options.md).
 
+### `--survey`
+
+> [!CAUTION]
+> This option is defunct and has been removed from vcpkg in current versions.
+
+Opens the vcpkg feedback survey in a web-browser window.
+


### PR DESCRIPTION
Documents the `vcpkg contact` command.

Depends on https://github.com/microsoft/vcpkg-tool/pull/1160