### PR TITLE
Document "Reference/Commands/vcpkg owns"

### DIFF
--- a/vcpkg/TOC.yml
+++ b/vcpkg/TOC.yml
@@ -256,6 +256,8 @@
           href: commands/integrate.md
         - name: vcpkg list
           href: commands/list.md
+        - name: vcpkg owns
+          href: commands/owns.md
         - name: vcpkg remove
           href: commands/remove.md
         - name: vcpkg search

--- a/vcpkg/commands/owns.md
+++ b/vcpkg/commands/owns.md
@@ -1,0 +1,35 @@
+---
+title: vcpkg owns
+description: Reference for the vcpkg owns command. Determines which installed package owns a particular file or files matching a substring.
+author: JavierMatosD
+ms.author: javiermat
+ms.date: 08/17/2023
+ms.prod: vcpkg
+---
+# vcpkg owns
+
+## Synopsis
+
+```console
+vcpkg owns <file-substr>
+```
+## Description
+
+The `owns` command is used to search for installed packages that own a particular file or files that match a substring (`<file-substr>`).
+
+The command outputs a list of packages that have files matching the given substring. Each entry is in the format:
+```console
+<package-name>: <file-path>
+```
+
+## Examples
+
+To search for installed packages that own a file matching the substring `zlib.dll`.
+
+```console
+vcpkg owns zlib.dll
+```
+
+## Options
+
+All vcpkg commands support a set of [common options](common-options.md).

--- a/vcpkg/commands/owns.md
+++ b/vcpkg/commands/owns.md
@@ -24,10 +24,14 @@ The command outputs a list of packages that have files matching the given substr
 
 ## Examples
 
-To search for installed packages that own a file matching the substring `zlib.dll`.
+To search for installed packages that own a file matching the substring `zlib.h`.
 
 ```console
-vcpkg owns zlib.dll
+vcpkg owns zlib.h
+
+-- zlib:x86-windows: x86-windows/include/zlib.h
+-- zlib:x64-windows: x64-windows/include/zlib.h
+-- bzip2:x64-windows: x64-windows/include/bzlib.h
 ```
 
 ## Options


### PR DESCRIPTION
Documents the `vcpkg owns` command.