### PR TITLE
Add background information on how toolchain leads to dependency acquisition

### DIFF
--- a/vcpkg/users/buildsystems/cmake-integration.md
+++ b/vcpkg/users/buildsystems/cmake-integration.md
@@ -6,7 +6,8 @@ ms.date: 11/30/2022
 
 # CMake Integration
 
-It is important to understand when and how vcpkg executes its dependency acquisition and build steps in the CMake context.
+It is important to understand how vcpkg hooks in to CMake to make packages available, and especially when and how vcpkg executes its dependency acquisition and build steps for manifest mode.
+
 As background: by default, the first time CMake configures a build, it runs internal search routines to locate a viable
 "toolchain" (compiler, linker, etc.). This search happens when the first `project()` command is encountered in `CMakeLists.txt`.
 
@@ -16,13 +17,19 @@ This evaluation typically results in a set of variable definitions containing th
 build parameters, such as cross-compilation flags).
 
 But because the toolchain file is just a CMake script, it is not limited to defining toolchain-related variables. vcpkg uses this
-fact as a hook into the CMake generation process. Evaluation of the `vcpkg.cmake` toolchain file effectively runs
-`execute_process("vcpkg install")`, after other precursor steps.
+fact as a hook into the CMake generation process. There are two ways this hook is used.
 
-**Therefore: all vcpkg-provided dependencies are downloaded and compiled the first time `project()` is called**. A key consequence
-of this sequence is that all CMake-level variables impacting vcpkg itself must be defined _before_ `project()`.
+In [classic mode](https://learn.microsoft.com/en-us/vcpkg/users/classic-mode), vcpkg simply makes packages which were manually
+installed using `vcpkg install` available to `find_{package,library,path}`.
+
+In [manifest mode](https://learn.microsoft.com/en-us/vcpkg/users/manifests), evaluation of the `vcpkg.cmake` toolchain file
+effectively runs `execute_process("vcpkg install")` direct, after other precursor steps. **Therefore, in manifest mode, all
+vcpkg-provided dependencies are downloaded and compiled the first time `project()` is called**. A key consequence of this
+sequence is that all CMake-level variables impacting vcpkg's build steps must be defined _before_ `project()`.
 
 See [Installing and Using Packages Example: sqlite](../../examples/installing-and-using-packages.md) for a fully worked example using CMake.
+
+(note that 
 
 ## `CMAKE_TOOLCHAIN_FILE`
 

--- a/vcpkg/users/buildsystems/cmake-integration.md
+++ b/vcpkg/users/buildsystems/cmake-integration.md
@@ -6,9 +6,27 @@ ms.date: 11/30/2022
 
 # CMake Integration
 
+It is important to understand when and how vcpkg executes its dependency acquisition and build steps in the CMake context.
+As background: by default, the first time CMake configures a build, it runs internal search routines to locate a viable
+"toolchain" (compiler, linker, etc.). This search happens when the first `project()` command is encountered in `CMakeLists.txt`.
+
+In order to customize this process, CMake supports "toolchain" files, which are really just CMake scripts.
+When a toolchain is specified, CMake **evaluates the `CMAKE_TOOLCHAIN_FILE` as a script**, just like `include("${CMAKE_TOOLCHAIN_FILE}")`
+This evaluation typically results in a set of variable definitions containing the paths of necessary build tools (along with other
+build parameters, such as cross-compilation flags).
+
+But because the toolchain file is just a CMake script, it is not limited to defining toolchain-related variables. vcpkg uses this
+fact as a hook into the CMake generation process. Evaluation of the `vcpkg.cmake` toolchain file effectively runs
+`execute_process("vcpkg install")`, after other precursor steps.
+
+**Therefore: all vcpkg-provided dependencies are downloaded and compiled the first time `project()` is called**. A key consequence
+of this sequence is that all CMake-level variables impacting vcpkg itself must be defined _before_ `project()`.
+
 See [Installing and Using Packages Example: sqlite](../../examples/installing-and-using-packages.md) for a fully worked example using CMake.
 
 ## `CMAKE_TOOLCHAIN_FILE`
+
+
 
 Projects configured to use the vcpkg toolchain file (via the CMake setting `CMAKE_TOOLCHAIN_FILE`) can find libraries from vcpkg using the standard CMake functions: `find_package()`, `find_path()`, and `find_library()`.
 

--- a/vcpkg/users/buildsystems/cmake-integration.md
+++ b/vcpkg/users/buildsystems/cmake-integration.md
@@ -26,8 +26,6 @@ See [Installing and Using Packages Example: sqlite](../../examples/installing-an
 
 ## `CMAKE_TOOLCHAIN_FILE`
 
-
-
 Projects configured to use the vcpkg toolchain file (via the CMake setting `CMAKE_TOOLCHAIN_FILE`) can find libraries from vcpkg using the standard CMake functions: `find_package()`, `find_path()`, and `find_library()`.
 
 We recommend using [CMake Presets] to specify your toolchain file. For example, if you have defined the environment variable `VCPKG_ROOT`, you can use the following `CMakePresets.json` and pass `--preset debug` on the configure line:

--- a/vcpkg/users/buildsystems/cmake-integration.md
+++ b/vcpkg/users/buildsystems/cmake-integration.md
@@ -19,17 +19,16 @@ build parameters, such as cross-compilation flags.
 But because the toolchain file is just a CMake script, it is not limited to defining toolchain-related variables. vcpkg uses this
 fact as a hook into the CMake generation process. There are two ways this hook is used.
 
-In [classic mode](https://learn.microsoft.com/en-us/vcpkg/users/classic-mode), vcpkg simply makes packages which were manually
-installed using `vcpkg install` available to `find_{package,library,path}`.
+In [classic mode](https://learn.microsoft.com/en-us/vcpkg/users/classic-mode), vcpkg sets CMake search paths appropriately to make
+previously-installed packages available via `find_{package,library,path}`.
 
 In [manifest mode](https://learn.microsoft.com/en-us/vcpkg/users/manifests), evaluation of the `vcpkg.cmake` toolchain file
 effectively runs `execute_process("vcpkg install")` directly, after other precursor steps. **Therefore, in manifest mode, all
 vcpkg-provided dependencies are downloaded and compiled the first time `project()` is called**. A key consequence of this
-sequence is that all CMake-level variables impacting vcpkg's build steps must be defined _before_ `project()`.
+sequence is that all CMake-level variables impacting vcpkg's build steps must be defined _before_ `project()`. Packages will be
+rebuilt as necessary whenever `project()` is called if any CMakeList modifications impact the [ABI hash](https://learn.microsoft.com/en-us/vcpkg/users/binarycaching#abi-hash).
 
 See [Installing and Using Packages Example: sqlite](../../examples/installing-and-using-packages.md) for a fully worked example using CMake.
-
-(note that 
 
 ## `CMAKE_TOOLCHAIN_FILE`
 

--- a/vcpkg/users/buildsystems/cmake-integration.md
+++ b/vcpkg/users/buildsystems/cmake-integration.md
@@ -13,8 +13,8 @@ As background: by default, the first time CMake configures a build, it runs inte
 
 In order to customize this process, CMake supports "toolchain" files, which are really just CMake scripts.
 When a toolchain is specified, CMake **evaluates the `CMAKE_TOOLCHAIN_FILE` as a script**, just like `include("${CMAKE_TOOLCHAIN_FILE}")`
-This evaluation typically results in a set of variable definitions containing the paths of necessary build tools (along with other
-build parameters, such as cross-compilation flags).
+This evaluation typically results in a set of variable definitions containing the paths of necessary build tools along with other
+build parameters, such as cross-compilation flags.
 
 But because the toolchain file is just a CMake script, it is not limited to defining toolchain-related variables. vcpkg uses this
 fact as a hook into the CMake generation process. There are two ways this hook is used.
@@ -23,7 +23,7 @@ In [classic mode](https://learn.microsoft.com/en-us/vcpkg/users/classic-mode), v
 installed using `vcpkg install` available to `find_{package,library,path}`.
 
 In [manifest mode](https://learn.microsoft.com/en-us/vcpkg/users/manifests), evaluation of the `vcpkg.cmake` toolchain file
-effectively runs `execute_process("vcpkg install")` direct, after other precursor steps. **Therefore, in manifest mode, all
+effectively runs `execute_process("vcpkg install")` directly, after other precursor steps. **Therefore, in manifest mode, all
 vcpkg-provided dependencies are downloaded and compiled the first time `project()` is called**. A key consequence of this
 sequence is that all CMake-level variables impacting vcpkg's build steps must be defined _before_ `project()`.
 

--- a/vcpkg/users/buildsystems/cmake-integration.md
+++ b/vcpkg/users/buildsystems/cmake-integration.md
@@ -19,14 +19,14 @@ build parameters, such as cross-compilation flags.
 But because the toolchain file is just a CMake script, it is not limited to defining toolchain-related variables. vcpkg uses this
 fact as a hook into the CMake generation process. There are two ways this hook is used.
 
-In [classic mode](https://learn.microsoft.com/en-us/vcpkg/users/classic-mode), vcpkg sets CMake search paths appropriately to make
+In [classic mode](../classic-mode.md), vcpkg sets CMake search paths appropriately to make
 previously-installed packages available via `find_{package,library,path}`.
 
-In [manifest mode](https://learn.microsoft.com/en-us/vcpkg/users/manifests), evaluation of the `vcpkg.cmake` toolchain file
+In [manifest mode](../manifests.md), evaluation of the `vcpkg.cmake` toolchain file
 effectively runs `execute_process("vcpkg install")` directly, after other precursor steps. **Therefore, in manifest mode, all
 vcpkg-provided dependencies are downloaded and compiled the first time `project()` is called**. A key consequence of this
 sequence is that all CMake-level variables impacting vcpkg's build steps must be defined _before_ `project()`. Packages will be
-rebuilt as necessary whenever `project()` is called if any CMakeList modifications impact the [ABI hash](https://learn.microsoft.com/en-us/vcpkg/users/binarycaching#abi-hash).
+rebuilt as necessary whenever `project()` is called if any CMakeList modifications impact the [ABI hash](../binarycaching.md#abi-hash).
 
 See [Installing and Using Packages Example: sqlite](../../examples/installing-and-using-packages.md) for a fully worked example using CMake.
 


### PR DESCRIPTION
This PR adds background information on how and when the use of `CMAKE_TOOLCHAIN_FILE` integration hooks into the actual acquisition of vcpkg-provided dependencies.

(x-ref https://github.com/microsoft/vcpkg-docs/pull/36 / https://github.com/microsoft/vcpkg/pull/29121)