### PR TITLE
Add concepts/registries and update links

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -4,6 +4,11 @@
             "source_path": "vcpkg/examples/manifest-mode-cmake.md",
             "redirect_url": "/vcpkg/consume/manifest-mode",
             "redirect_document_id": true
+        },
+        {
+            "source_path": "vcpkg/users/registries.md",
+            "redirect_url": "/vcpkg/concepts/registries",
+            "redirect_document_id": true
         }
     ]
 }

--- a/vcpkg/TOC.yml
+++ b/vcpkg/TOC.yml
@@ -117,7 +117,7 @@
   - name: Ports
     href: concepts/ports.md
   - name: Registries
-    href: users/registries.md
+    href: concepts/registries.md
   - name: Script ports
     href: maintainers/authoring-script-ports.md
   - name: Triplets

--- a/vcpkg/TOC.yml
+++ b/vcpkg/TOC.yml
@@ -114,6 +114,8 @@
       href: contributing/pr-review-checklist.md
   - name: Overlay ports
     href: concepts/overlay-ports.md
+  - name: Package name resolution
+    href: concepts/package-name-resolution.md
   - name: Ports
     href: concepts/ports.md
   - name: Registries

--- a/vcpkg/commands/common-options.md
+++ b/vcpkg/commands/common-options.md
@@ -104,7 +104,7 @@ Defaults to searching upwards from the current working directory for the nearest
 
 ### <a name="overlay-ports"></a> `--overlay-ports=<path>`
 
-Specifies a directory containing [overlay ports](../users/registries.md#overlays).
+Specifies a directory containing [overlay ports](../concepts/package-name-resolution.md#overlays).
 
 This option can be specified multiple times; ports will resolve to the first match.
 

--- a/vcpkg/commands/update-baseline.md
+++ b/vcpkg/commands/update-baseline.md
@@ -15,7 +15,7 @@ vcpkg x-update-baseline [options] [--add-initial-baseline] [--dry-run]
 
 ## Description
 
-Update baselines for all configured [registries](../users/registries.md).
+Update baselines for all configured [registries](../reference/vcpkg-configuration-json.md#registries).
 
 In [Manifest mode](../users/manifests.md), this command operates on all registries in the [`vcpkg.json`](../reference/vcpkg-json.md) and the [`vcpkg-configuration.json`](../reference/vcpkg-configuration-json.md). In Classic mode, this command operates on the `vcpkg-configuration.json` in the vcpkg instance (`$VCPKG_ROOT`).
 
@@ -35,4 +35,4 @@ Print the planned baseline upgrades, but do not modify the files on disk.
 
 Add a [`"builtin-baseline"`](../reference/vcpkg-json.md#builtin-baseline) field to the `vcpkg.json` if it does not already have one.
 
-Without this flag, it is an error to run this command on a manifest that does not have any [registries](../users/registries.md) configured.
+Without this flag, it is an error to run this command on a manifest that does not have any [registries](../reference/vcpkg-configuration-json.md#registries) configured.

--- a/vcpkg/concepts/overlay-ports.md
+++ b/vcpkg/concepts/overlay-ports.md
@@ -12,7 +12,7 @@ ms.topic: concept-article
 
 Usually, vcpkg ports are obtained from [registries](../concepts/registries.md). It is very likely that most of the ports you install come from the official vcpkg registry at <https://github.com/Microsoft/vcpkg>. vcpkg lets you install ports available to you via the file system, we call these ports, overlay ports.
 
-An overlay port can act as a drop-in replacement for an existing port or as a new port that is otherwise not available in a [registry](../maintainers/registries.md). While [resolving package names](../users/registries.md#package-name-resolution), overlay ports take priority.
+An overlay port can act as a drop-in replacement for an existing port or as a new port that is otherwise not available in a [registry](../maintainers/registries.md). While [resolving package names](../concepts/package-name-resolution.md), overlay ports take priority.
 
 Overlay ports are evaluated in the following order:
 

--- a/vcpkg/concepts/overlay-ports.md
+++ b/vcpkg/concepts/overlay-ports.md
@@ -10,7 +10,7 @@ ms.topic: concept-article
 
 # Overlay ports
 
-Usually, vcpkg ports are obtained from [registries](../users/registries.md). It is very likely that most of the ports you install come from the official vcpkg registry at <https://github.com/Microsoft/vcpkg>. vcpkg lets you install ports available to you via the file system, we call these ports, overlay ports.
+Usually, vcpkg ports are obtained from [registries](../concepts/registries.md). It is very likely that most of the ports you install come from the official vcpkg registry at <https://github.com/Microsoft/vcpkg>. vcpkg lets you install ports available to you via the file system, we call these ports, overlay ports.
 
 An overlay port can act as a drop-in replacement for an existing port or as a new port that is otherwise not available in a [registry](../maintainers/registries.md). While [resolving package names](../users/registries.md#package-name-resolution), overlay ports take priority.
 

--- a/vcpkg/concepts/package-name-resolution.md
+++ b/vcpkg/concepts/package-name-resolution.md
@@ -210,5 +210,4 @@ Overlay settings are evaluated in this order:
    [`vcpkg-configuration.json`](../reference/vcpkg-configuration-json.md#overlay-ports)
    in order; then
 3. Overlays from the `VCPKG_OVERLAY_[PORTS|TRIPLETS]` [environment
-   variables](config-environment.md#vcpkg_overlay_ports) in order
-
+   variables](../users/config-environment.md#vcpkg_overlay_ports) in order.

--- a/vcpkg/concepts/registries.md
+++ b/vcpkg/concepts/registries.md
@@ -10,18 +10,18 @@ ms.topic: concept-article
 
 # Registries concepts
 
-Registries are collections of ports and their versions. The curent catalog of
-ports in vcpkg is distributed via the registry at
-<https://github.com/Microsoft/vcpkg>. vcpkg lets you create your own custom
-registries which you can make either public or private, and host them in a
+Registries are collections of ports and their versions. The current catalog of
+ports in vcpkg are distributed via the registry at
+<https://github.com/Microsoft/vcpkg>. vcpkg lets you create your custom
+registries, which you can make either public or private, and host them in a
 variety of storage providers.
 
 There are currently two options to implement your own registries: a Git-based
-registriy or a filesystem-based registries.
+registry or a filesystem-based registry.
 
 ## Built-in registry
 The built-in registry refers to the main vcpkg registry at
-<https://github.com/Microsoft/vcpkg>. Depending on the vcpkg operation mode this
+<https://github.com/Microsoft/vcpkg>. Depending on the vcpkg operation mode, this
 can mean your local clone of the vcpkg repository or the remote repository
 hosted in GitHub.
 
@@ -30,7 +30,7 @@ Git registries are simple Git repositories. They can be shared publicly or
 privately via normal mechanisms for Git repositories. The [vcpkg
 repository](https://github.com/microsoft/vcpkg) is an example of a Git registry.
 
-Using Git registries offers the best experience for custom registries, since you
+Using Git registries offers the best experience for custom registries since you
 have full control over the versions and contents of your registry.
 
 ## Filesystem registries

--- a/vcpkg/concepts/registries.md
+++ b/vcpkg/concepts/registries.md
@@ -1,0 +1,45 @@
+---
+title: Registries concepts
+description: Concepts about vcpkg registries and their capabilities.
+author: vicroms
+ms.author: viromer
+ms.date: 10/24/2023
+ms.prod: vcpkg
+ms.topic: concept-article
+---
+
+# Registries concepts
+
+Registries are collections of ports and their versions. The curent catalog of
+ports in vcpkg is distributed via the registry at
+<https://github.com/Microsoft/vcpkg>. vcpkg lets you create your own custom
+registries which you can make either public or private, and host them in a
+variety of storage providers.
+
+There are currently two options to implement your own registries: a Git-based
+registriy or a filesystem-based registries.
+
+## Git registries
+Git registries are simple Git repositories. They can be shared publicly or
+privately via normal mechanisms for Git repositories. The [vcpkg
+repository](https://github.com/microsoft/vcpkg) is an example of a Git registry.
+
+Using Git registries offers the best experience for custom registries, since you
+have full control over the versions and contents of your registry.
+
+## Filesystem registries
+Filesystem registries, as the name implies, live on your filesystem. They are a
+collection of ports located in a filesystem location and offer a primitive form
+of version control using a separate path per version.
+
+These type of registries are more suited to be a testing ground for your
+packages. Or to provide an alternative for registries in version control systems
+that are not Git.
+
+## Next steps
+
+Here are some tasks to try next:
+
+* [Create your own Git-based registry](../produce/publish-to-a-git-registry.md)
+* [Install packages from a custom registry](../consume/git-registries.md)
+* [Read the registries reference documentatin](../maintainers/registries.md)

--- a/vcpkg/concepts/registries.md
+++ b/vcpkg/concepts/registries.md
@@ -19,6 +19,12 @@ variety of storage providers.
 There are currently two options to implement your own registries: a Git-based
 registriy or a filesystem-based registries.
 
+## Built-in registry
+The built-in registry refers to the main vcpkg registry at
+<https://github.com/Microsoft/vcpkg>. Depending on the vcpkg operation mode this
+can mean your local clone of the vcpkg repository or the remote repository
+hosted in GitHub.
+
 ## Git registries
 Git registries are simple Git repositories. They can be shared publicly or
 privately via normal mechanisms for Git repositories. The [vcpkg

--- a/vcpkg/consume/git-registries.md
+++ b/vcpkg/consume/git-registries.md
@@ -121,7 +121,7 @@ The configuration file adds an external registry as the source for the `beicode`
 packages. Additional registries must explicitly declare the packages they provide using the
 `"packages"` list.  When vcpkg resolves packages names to a registry, any package name not found in
 an additional registry will be defaulted to the `"default-registry"`. Learn more about [package name
-resolution](../users/registries.md#package-name-resolution) in the registries documentation.
+resolution](../concepts/package-name-resolution.md) in the registries documentation.
 
 ## 4 - Install packages from a registry
 

--- a/vcpkg/consume/manifest-mode.md
+++ b/vcpkg/consume/manifest-mode.md
@@ -22,7 +22,7 @@ unlike classic mode, where all packages are installed in a common `%VCPKG_ROOT%/
 directory. Therefore, each project can have its own manifest and its own set of dependencies that do not conflict with other projects' dependencies.
 
 Manifest mode is also required to use advanced features like
-[versioning](../users/versioning.md) and [custom registries](../users/registries.md).
+[versioning](../users/versioning.md) and [custom registries](../concepts/registries.md).
 
 In this tutorial, you will learn how to:
 

--- a/vcpkg/get_started/overview.md
+++ b/vcpkg/get_started/overview.md
@@ -45,7 +45,7 @@ vcpkg has a unique way of handling [package versions](../users/versioning.concep
 
 ### Registries
 
-A [registry](../users/registries.md) is a catalog of ports and available versions that a vcpkg user can install. vcpkg provides a public registry of open-source libraries by default, but you can also define your own registries for custom libraries.
+A [registry](../concepts/registries.md) is a catalog of ports and available versions that a vcpkg user can install. vcpkg provides a public registry of open-source libraries by default, but you can also define your own registries for custom libraries.
 
 ### Asset caching
 

--- a/vcpkg/maintainers/registries.md
+++ b/vcpkg/maintainers/registries.md
@@ -6,7 +6,7 @@ ms.topic: tutorial
 ---
 # Creating registries
 
-For information on consuming registries, see [Using registries](../users/registries.md).
+For information on consuming registries, see [Using registries](../consume/git-registries.md).
 
 ## Overview
 

--- a/vcpkg/produce/publish-to-a-git-registry.md
+++ b/vcpkg/produce/publish-to-a-git-registry.md
@@ -139,6 +139,6 @@ And that's it! You have set up your own private Git-based registry to use with v
 
 Here are some additional tasks to try next:
 
-* [Install dependencies from a private registry](../users/registries.md)
+* [Install dependencies from a private registry](../consume/git-registries.md)
 * [Authenticate to registries using private Git repositories](../users/authentication.md)
 <!--[Set up package validation in your private registry]-->

--- a/vcpkg/reference/vcpkg-configuration-json.md
+++ b/vcpkg/reference/vcpkg-configuration-json.md
@@ -12,7 +12,7 @@ In [Manifest Mode](../users/manifests.md), `vcpkg-configuration.json` can be in 
 
 In [Classic Mode](../users/classic-mode.md), vcpkg will use the `vcpkg-configuration.json` file in the [root](../commands/common-options.md#vcpkg-root) of the vcpkg instance.
 
-For an overview of using registries with vcpkg, see [Using Registries](../users/registries.md).
+For an overview of using registries with vcpkg, see [Using Registries](../consume/git-registries.md).
 
 The latest JSON Schema is available at [https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json](https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json). IDEs with JSON Schema support such as Visual Studio and Visual Studio Code can use this file to provide autocomplete and syntax checking. For most IDEs, you should set `"$schema"` in your `vcpkg-configuration.json` to this URL.
 

--- a/vcpkg/reference/vcpkg-configuration-json.md
+++ b/vcpkg/reference/vcpkg-configuration-json.md
@@ -158,7 +158,7 @@ Package patterns may contain only lowercase letters, digits, and `-`, with an op
 * `a+` (`+` is not a valid pattern character)
 * `a?` (`?` is not a valid pattern character)
 
-See the [Using Registries documentation](../users/registries.md#package-name-resolution) for more information on how port names are resolved.
+See the [Using Registries documentation](../concepts/package-name-resolution.md) for more information on how port names are resolved.
 
 [Git Registry]: ../maintainers/registries.md#git-registries
 [Filesystem Registry]: ../maintainers/registries.md#filesystem-registries

--- a/vcpkg/reference/vcpkg-json.md
+++ b/vcpkg/reference/vcpkg-json.md
@@ -65,7 +65,7 @@ This field indicates the commit of <https://github.com/microsoft/vcpkg> which pr
 }
 ```
 
-See [versioning](../users/versioning.md#baselines) and [Using registries](../users/registries.md) for more semantic details.
+See [versioning](../users/versioning.md#baselines) and [Using registries](../consume/git-registries.md) for more semantic details.
 
 ### <a name="default-features"></a> `"default-features"`
 
@@ -259,7 +259,7 @@ For example, if your library doesn't support building for Linux, you would use `
 
 ### `"vcpkg-configuration"`
 
-Allows to embed vcpkg configuration properties inside the `vcpkg.json` file. Everything inside the `vcpkg-configuration` property is treated as if it were defined in a `vcpkg-configuration.json` file. For more details, see the [`vcpkg-configuration.json`](../users/registries.md) documentation.
+Allows to embed vcpkg configuration properties inside the `vcpkg.json` file. Everything inside the `vcpkg-configuration` property is treated as if it were defined in a `vcpkg-configuration.json` file. For more details, see the [`vcpkg-configuration.json`](../reference/vcpkg-configuration-json.md#registries) documentation.
 
 Having a `vcpkg-configuration` defined in `vcpkg.json` while also having a `vcpkg-configuration.json` file is not allowed and will result in the vcpkg command terminating with an error message.
 


### PR DESCRIPTION
We should consider repurposing `users/registries.md` to become an article that explains package name resolution. Since currently it is only tangentially related to the registries feature.