### PR TITLE
Fix env.md error

### DIFF
--- a/vcpkg/commands/env.md
+++ b/vcpkg/commands/env.md
@@ -68,7 +68,7 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).
 PS C:\Users\vcpkg\vcpkg> $env:CLEARED_ENV_VAR="hello"
 PS C:\Users\vcpkg\vcpkg> vcpkg env "set CLEARED_ENV_VAR"
 Environment variable CLEARED_ENV_VAR not defined
-PS C:\Users\vcpkg\vcpkg> $env:KEEP_ENV_VARS="CLEARED_ENV_VAR"
+PS C:\Users\vcpkg\vcpkg> $env:VCPKG_KEEP_ENV_VARS="CLEARED_ENV_VAR"
 PS C:\Users\vcpkg\vcpkg> vcpkg env "set CLEARED_ENV_VAR"
 CLEARED_ENV_VAR=hello
 ```


### PR DESCRIPTION
Fixed #208.

Fix [`env.md`](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/commands/env.md#preserve-environment-variables) error: Change `KEEP_ENV_VARS` to `VCPKG_KEEP_ENV_VARS`:
```
PS C:\Users\vcpkg\vcpkg> $env:CLEARED_ENV_VAR="hello"
PS C:\Users\vcpkg\vcpkg> vcpkg env "set CLEARED_ENV_VAR"
Environment variable CLEARED_ENV_VAR not defined
PS C:\Users\vcpkg\vcpkg> $env:KEEP_ENV_VARS="CLEARED_ENV_VAR"
PS C:\Users\vcpkg\vcpkg> vcpkg env "set CLEARED_ENV_VAR"
CLEARED_ENV_VAR=hello
```

![image](https://github.com/microsoft/vcpkg-docs/assets/110024546/fd3a2239-dd0c-4c9b-a390-1cda2126e377)
