### PR TITLE
Fixed `env` macro in 'Getting Started' example `CMakePresets.json` file.

### DIFF
--- a/vcpkg/examples/snippets/get-started/CMakePresets.json
+++ b/vcpkg/examples/snippets/get-started/CMakePresets.json
@@ -1,12 +1,12 @@
 {
-  "version": 3,
-  "configurePresets": [
-    {
-      "name": "default",
-      "binaryDir": "${sourceDir}/build",
-      "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-      }
-    }
-  ]
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
## Details

They current example `CMakePresets.json` uses the environment macro `$ENV{VAR_NAME}` instead of `$env{VAR_NAME}`. Using the capitalised version results in CMake failing which could confuse readers (I know I was) as CMake doesn't give a good error message likely because it treats `$ENV{VAR_NAME}` literally. I have corrected the typo.

I believe the error might have been a copy+paste error from a `CMakeLists.txt` or `*.cmake` because these files **do** use the capitalised macro for accessing environment variables which is a weird inconsistency in CMake.

## Linked

- #213 
