### PR TITLE
Update android.md to use NDK r26c

### DIFF
--- a/vcpkg/users/platforms/android.md
+++ b/vcpkg/users/platforms/android.md
@@ -58,11 +58,11 @@ RUN \
 
 # Download Android NDK
 RUN \
-  wget https://dl.google.com/android/repository/android-ndk-r26b-linux.zip && \
-  unzip android-ndk-r26b-linux.zip && \
-  rm -rf android-ndk-r26b-linux.zip
+  wget https://dl.google.com/android/repository/android-ndk-r26c-linux.zip && \
+  unzip android-ndk-r26c-linux.zip && \
+  rm -rf android-ndk-r26c-linux.zip
 
-ENV ANDROID_NDK_HOME /android-ndk-r26b
+ENV ANDROID_NDK_HOME /android-ndk-r26c
 
 RUN git clone https://github.com/microsoft/vcpkg
 WORKDIR vcpkg

--- a/vcpkg/users/platforms/android.md
+++ b/vcpkg/users/platforms/android.md
@@ -58,11 +58,11 @@ RUN \
 
 # Download Android NDK
 RUN \
-  wget https://dl.google.com/android/repository/android-ndk-r25c-linux.zip && \
-  unzip android-ndk-r25c-linux.zip && \
-  rm -rf android-ndk-r25c-linux.zip
+  wget https://dl.google.com/android/repository/android-ndk-r26b-linux.zip && \
+  unzip android-ndk-r26b-linux.zip && \
+  rm -rf android-ndk-r26b-linux.zip
 
-ENV ANDROID_NDK_HOME /android-ndk-r25c
+ENV ANDROID_NDK_HOME /android-ndk-r26b
 
 RUN git clone https://github.com/microsoft/vcpkg
 WORKDIR vcpkg


### PR DESCRIPTION
Latest NDK is r26b, released 2023-10-11.

https://github.com/android/ndk/releases/tag/r26b

I have done a basic test by performing jsoncpp compilation with updated image.