### PR TITLE
Fix `greet` to match tutorial

### DIFF
--- a/my_sample_lib.cpp
+++ b/my_sample_lib.cpp
@@ -1,6 +1,6 @@
 #include "my_sample_lib.h"
 #include <fmt/core.h>
 
-std::string greet(const std::string& name) {
-    return fmt::format("Hello, {}!", name);
+void greet(const std::string& name) {
+    fmt::print("Hello, {}!\n", name);
 }

--- a/my_sample_lib.h
+++ b/my_sample_lib.h
@@ -5,4 +5,4 @@
 #if MYLIB_EXPORTS
 __declspec(dllexport)
 #endif
-std::string greet(const std::string& name);
+void greet(const std::string& name);


### PR DESCRIPTION
As it is, the code prints nothing. I think this is what was intended.