### PR TITLE
Fix getting started with VS Code example

### DIFF
--- a/vcpkg/get_started/get-started-vscode.md
+++ b/vcpkg/get_started/get-started-vscode.md
@@ -165,7 +165,7 @@ Create `CMakeUserPresets.json` file in the "helloworld" directory with the follo
 }
 ```
 
-This `CMakePresets.json` file contains a single "vcpkg" preset for CMake and sets the `CMAKE_TOOLCHAIN_FILE` variable. The `CMAKE_TOOLCHAIN_FILE` allows the CMake project system to recognize C++ libraries provided by vcpkg. Only `CMakePresets.json` is meant to be checked into source while `CMakeUserPresets.json` is to be used locally.
+This `CMakePresets.json` file contains a single "vcpkg" preset for CMake and sets the `CMAKE_TOOLCHAIN_FILE` variable. The `CMAKE_TOOLCHAIN_FILE` allows the CMake project system to recognize C++ libraries provided by vcpkg. Only `CMakePresets.json` is meant to be checked into source control while `CMakeUserPresets.json` is to be used locally.
 
 4 - Build and run the project
 

--- a/vcpkg/get_started/get-started-vscode.md
+++ b/vcpkg/get_started/get-started-vscode.md
@@ -10,13 +10,13 @@ ms.prod: vcpkg
 ms.topic: tutorial
 ---
 
-# Tutorial: Install and use packages with CMake in VS Code
+# Tutorial: Install and use packages with CMake in Visual Studio Code
 
 This tutorial shows you how to create a C++ "Hello World" program that uses the `fmt` library with CMake, vcpkg and Visual Studio Code. You'll install dependencies, configure, build, and run a simple application.
 
 ## Prerequisites
 
-- [VS Code](https://code.visualstudio.com)
+- [Visual Studio Code](https://code.visualstudio.com)
 - [C++ compiler](https://code.visualstudio.com/docs/languages/cpp#_install-a-compiler)
 - Windows 7 or newer
 
@@ -26,25 +26,25 @@ This example uses the C++ MSVC compiler in the Visual Studio C++ development wor
 
 [!INCLUDE [setup-vcpkg](includes/setup-vcpkg.md)]
 
-## 2 - Install VS Code Extensions
+## 2 - Install Visual Studio Code Extensions
 
 Navigate to the Extension view, and install the [C++ Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools). This enables C++ IntelliSense and code navigation.
 
-:::image type="complex" source="../resources/get_started/vscode-c-extension.png" alt-text="installing C++ VS Code Extension":::
-  Screenshot of VS Code Extension view with C++ Extension
+:::image type="complex" source="../resources/get_started/vscode-c-extension.png" alt-text="installing C++ Visual Studio Code Extension":::
+  Screenshot of Visual Studio Code Extension view with C++ Extension
 :::image-end:::
 
-Install the [CMake Tools Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools). This enables CMake support in VS Code.
+Install the [CMake Tools Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools). This enables CMake support in Visual Studio Code.
 
-:::image type="complex" source="../resources/get_started/vscode-cmake-extension.png" alt-text="installing CMake Tools VS Code Extension":::
-  Screenshot of VS Code Extension view with CMake Tools Extension
+:::image type="complex" source="../resources/get_started/vscode-cmake-extension.png" alt-text="installing CMake Tools Visual Studio Code Extension":::
+  Screenshot of Visual Studio Code Extension view with CMake Tools Extension
 :::image-end:::
 
 ## 3 - Setup vcpkg
 
 1. Configure the `VCPKG_ROOT` environmental variable.
 
-Open a new Terminal in VS Code: **Terminal > New Terminal**
+Open a new Terminal in Visual Studio Code: **Terminal > New Terminal**
 
 Run the following commands:
 ::: zone pivot="shell-powershell"
@@ -55,7 +55,7 @@ $env:PATH = "$env:VCPKG_ROOT;$env:PATH"
 ```
 
 :::image type="complex" source="../resources/get_started/vscode-terminal-vcpkg.png" alt-text="setting up vcpkg environment variables":::
-  Screenshot of setting up VCPKG_ROOT and adding it to PATH in a VS Code terminal.
+  Screenshot of setting up VCPKG_ROOT and adding it to PATH in a Visual Studio Code terminal.
 :::image-end:::
 
 ::: zone-end
@@ -131,22 +131,54 @@ In this `helloworld.cpp` file, the `<fmt/core.h>` header is included for using t
 
 To allow the CMake project system to recognize C++ libraries provided by vcpkg, you'll need to provide the `vcpkg.cmake` toolchain file. To automate this, create a `CMakePresets.json` file in the "helloworld" directory with the following content:
 
-:::code language="cmake" source="../examples/snippets/get-started/CMakePresets.json":::
+```cmake
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "vcpkg",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": {
+                   "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+                    "type": "FILEPATH"
+                }
+            }
+        }
+    ]
+}
+```
 
-This `CMakePresets.json` file contains a single "default" preset for CMake and sets the `CMAKE_TOOLCHAIN_FILE` variable. The `CMAKE_TOOLCHAIN_FILE` allows the CMake project system to recognize C++ libraries provided by vcpkg. Adding the `CMakePresets.json` automates the process of specifying the toolchain when running CMake.
+Create `CMakeUserPresets.json` file in the "helloworld" directory with the following content:
+
+```cmake
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "inherits": "vcpkg",
+            "environment": {
+                "VCPKG_ROOT": "<path to vcpkg>"
+            }
+        }
+    ]
+}
+```
+
+This `CMakePresets.json` file contains a single "vcpkg" preset for CMake and sets the `CMAKE_TOOLCHAIN_FILE` variable. The `CMAKE_TOOLCHAIN_FILE` allows the CMake project system to recognize C++ libraries provided by vcpkg. Only `CMakePresets.json` is meant to be checked into source while `CMakeUserPresets.json` is to be used locally.
 
 4 - Build and run the project
 
 1. Run the `CMake: Build` command the project by navigating to the Command Palette in **View > Command Palette**
 
-:::image type="complex" source="../resources/get_started/vscode-command-build.png" alt-text="CMake build command in VS Code":::
-  Screenshot of selecting the CMake build command in VS Code.
+:::image type="complex" source="../resources/get_started/vscode-command-build.png" alt-text="CMake build command in Visual Studio Code":::
+  Screenshot of selecting the CMake build command in Visual Studio Code.
 :::image-end:::
 
 Select the `default` CMake preset. This enables the vcpkg toolchain.
 
-:::image type="complex" source="../resources/get_started/vscode-command-build-preset.png" alt-text="Selecting preset in CMake build command in VS Code":::
-  Screenshot of selecting the preset in the CMake build command in VS Code.
+:::image type="complex" source="../resources/get_started/vscode-command-build-preset.png" alt-text="Selecting preset in CMake build command in Visual Studio Code":::
+  Screenshot of selecting the preset in the CMake build command in Visual Studio Code.
 :::image-end:::
 
 2. Launch the project


### PR DESCRIPTION
Changes name from VS Code to Visual Studio Code for clarity. Adds `CMakeUserPresets.json` to set `VCPKG_ROOT` as recommended by upstream.