### PR TITLE
Correct environment variable to pass additional `make` options

### DIFF
--- a/vcpkg/users/triplets.md
+++ b/vcpkg/users/triplets.md
@@ -145,7 +145,7 @@ This field is optional.
 Also available as build-type specific `VCPKG_CMAKE_CONFIGURE_OPTIONS_DEBUG` and
 `VCPKG_CMAKE_CONFIGURE_OPTIONS_RELEASE` variables.
 
-### VCPKG_MAKE_CONFIGURE_OPTIONS
+### VCPKG_CONFIGURE_MAKE_OPTIONS
 
 Set additional automake/autoconf configure options that are appended to the
 configure command (in
@@ -156,11 +156,11 @@ This field is optional.
 For example, to skip certain libtool checks that may errantly fail:
 
 ```cmake
-set(VCPKG_MAKE_CONFIGURE_OPTIONS "lt_cv_deplibs_check_method=pass_all")
+set(VCPKG_CONFIGURE_MAKE_OPTIONS "lt_cv_deplibs_check_method=pass_all")
 ```
 
-Also available as build-type specific `VCPKG_MAKE_CONFIGURE_OPTIONS_DEBUG` and
-`VCPKG_MAKE_CONFIGURE_OPTIONS_RELEASE` variables.
+Also available as build-type specific `VCPKG_CONFIGURE_MAKE_OPTIONS_DEBUG` and
+`VCPKG_CONFIGURE_MAKE_OPTIONS_RELEASE` variables.
 
 ### VCPKG_DEP_INFO_OVERRIDE_VARS
 


### PR DESCRIPTION
Fixes #137 