### PR TITLE
Fix binary-caching-local.md

### DIFF
--- a/vcpkg/consume/binary-caching-local.md
+++ b/vcpkg/consume/binary-caching-local.md
@@ -66,14 +66,14 @@ Next set the value of `VCPKG_BINARY_SOURCES` as follows:
 ::: zone pivot="shell-powershell"
 
 ```PowerShell
-$env:VCPKG_BINARY_SOURCES="clear;files,\\remote\shared\vcpkg\binary-cache,read;files,D:\vcpkg\binary-cache"
+$env:VCPKG_BINARY_SOURCES="clear;files,\\remote\shared\vcpkg\binary-cache,read;files,D:\vcpkg\binary-cache,readwrite"
 ```
 
 ::: zone-end
 ::: zone pivot="shell-cmd"
 
 ```console
-set VCPKG_BINARY_SOURCES="clear;files,\\remote\shared\vcpkg\binary-cache,read;files,D:\vcpkg\binary-cache"
+set VCPKG_BINARY_SOURCES="clear;files,\\remote\shared\vcpkg\binary-cache,read;files,D:\vcpkg\binary-cache,readwrite"
 ```
 
 ::: zone-end
@@ -84,16 +84,15 @@ This `VCPKG_BINARY_SOURCES` configuration adds the following source strings:
   binary cache](binary-caching-local.md).
 * `files,\\remote\shared\vcpkg\binary-cache,read`, sets a binary cache using the filesystem backend,
   `files`, located in `\\remote\shared\vcpkg\binary-cache`, and gives it read-only permissions
-  (`read`).
-* `files,D:\vcpkg\binary-cache`, sets a second filesystem binary cache, located in
-  `D:\vcpkg\binary-cache`, with read-write permissions (`readwrite` is omitted since it is the
-  default permission).
+  (`read` is the default permission).
+* `files,D:\vcpkg\binary-cache,readwrite`, sets a second filesystem binary cache, located in
+  `D:\vcpkg\binary-cache`, and gives it read-write permissions (`readwrite`).
 ::: zone-end
 
 ::: zone pivot="shell-bash"
 
 ```bash
-export VCPKG_BINARY_SOURCES="clear;files,/mnt/remote/shared/vcpkg/binary-cache,read;files,/home/vcpkg/binary-cache"
+export VCPKG_BINARY_SOURCES="clear;files,/mnt/remote/shared/vcpkg/binary-cache,read;files,/home/vcpkg/binary-cache,readwrite"
 ```
 
 This `VCPKG_BINARY_SOURCES` configuration adds the following source strings:
@@ -102,10 +101,9 @@ This `VCPKG_BINARY_SOURCES` configuration adds the following source strings:
   binary cache](binary-caching-local.md).
 * `files,/mnt/remote/shared/vcpkg/binary-cache,read`, sets a binary cache using the filesystem backend,
   `files`, located in `/mnt/remote/shared/vcpkg/binary-cache`, and gives it read-only permissions
-  (`read`).
-* `files,/home/vcpkg/binary-cache`, sets a second filesystem binary cache, located in
-  `/home/vcpkg/binary-cache`, with read-write permissions (`readwrite` is omitted since it is the
-  default permission).
+  (`read` is the default permission).
+* `files,/home/vcpkg/binary-cache,readwrite`, sets a second filesystem binary cache, located in
+  `/home/vcpkg/binary-cache`, and gives it read-write permissions (`readwrite`).
 
 ::: zone-end
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg-docs/issues/276.

Documentation error: 
The default permission in environment variable `VCPKG_BINARY_SOURCES` is `read` instead of `readwrite`. See the error:
[binary-caching-local.md?plain=1#L61-L107](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/consume/binary-caching-local.md?plain=1#L61-L107)

The correct explanation is here:
[binarycaching.md?plain=1#L94-L96](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/users/binarycaching.md?plain=1#L94-L96)