### PR TITLE
Change `CMakePresets.json` sample files to use schema version 1

### DIFF
--- a/vcpkg/examples/snippets/get-started/CMakePresets.json
+++ b/vcpkg/examples/snippets/get-started/CMakePresets.json
@@ -1,12 +1,13 @@
 {
-    "version": 3,
-    "configurePresets": [
-        {
-            "name": "default",
-            "binaryDir": "${sourceDir}/build",
-            "cacheVariables": {
-                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-            }
-        }
-    ]
+  "version": 1,
+  "configurePresets": [
+    {
+      "name": "default",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    }
+  ]
 }

--- a/vcpkg/examples/snippets/get-started/CMakePresets.json
+++ b/vcpkg/examples/snippets/get-started/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "configurePresets": [
     {
       "name": "default",

--- a/vcpkg/get_started/get-started-vs.md
+++ b/vcpkg/get_started/get-started-vs.md
@@ -127,15 +127,17 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
   
     ```json
     {
-    "version": 3,
-    "configurePresets": [
+      "version": 1,
+      "configurePresets": [
         {
-        "name": "default",
-        "cacheVariables": {
+          "name": "default",
+          "generator": "Ninja",
+          "binaryDir": "${sourceDir}/build",
+          "cacheVariables": {
             "CMAKE_TOOLCHAIN_FILE": "<VCPKG_ROOT>/scripts/buildsystems/vcpkg.cmake"
+          }
         }
-        }
-    ]
+      ]
     }
     ```
 

--- a/vcpkg/get_started/get-started-vs.md
+++ b/vcpkg/get_started/get-started-vs.md
@@ -127,7 +127,7 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
   
     ```json
     {
-      "version": 1,
+      "version": 2,
       "configurePresets": [
         {
           "name": "default",

--- a/vcpkg/get_started/get-started-vscode.md
+++ b/vcpkg/get_started/get-started-vscode.md
@@ -158,7 +158,6 @@ you'll need to provide the `vcpkg.cmake` toolchain file. To automate this,
 create a `CMakePresets.json` file in the "helloworld" directory with the
 following content:
 
-:::code language="cmake" source="../examples/snippets/get-started/CMakePresets.json":::
 
 ```json
 {

--- a/vcpkg/get_started/get-started-vscode.md
+++ b/vcpkg/get_started/get-started-vscode.md
@@ -158,20 +158,21 @@ you'll need to provide the `vcpkg.cmake` toolchain file. To automate this,
 create a `CMakePresets.json` file in the "helloworld" directory with the
 following content:
 
+:::code language="cmake" source="../examples/snippets/get-started/CMakePresets.json":::
+
 ```json
 {
-    "version": 3,
-    "configurePresets": [
-        {
-            "name": "vcpkg",
-            "cacheVariables": {
-                "CMAKE_TOOLCHAIN_FILE": {
-                   "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-                    "type": "FILEPATH"
-                }
-            }
-        }
-    ]
+  "version": 1,
+  "configurePresets": [
+    {
+      "name": "vcpkg",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    }
+  ]
 }
 ```
 
@@ -180,16 +181,16 @@ following content:
 
 ```json
 {
-    "version": 3,
-    "configurePresets": [
-        {
-            "name": "default",
-            "inherits": "vcpkg",
-            "environment": {
-                "VCPKG_ROOT": "<path to vcpkg>"
-            }
-        }
-    ]
+  "version": 1,
+  "configurePresets": [
+    {
+      "name": "default",
+      "inherits": "vcpkg",
+      "environment": {
+        "VCPKG_ROOT": "<path to vcpkg>"
+      }
+    }
+  ]
 }
 ```
 

--- a/vcpkg/get_started/get-started-vscode.md
+++ b/vcpkg/get_started/get-started-vscode.md
@@ -161,7 +161,7 @@ following content:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "configurePresets": [
     {
       "name": "vcpkg",
@@ -180,7 +180,7 @@ following content:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "configurePresets": [
     {
       "name": "default",

--- a/vcpkg/users/buildsystems/snippets/cmake-integration/CMakePresets.json
+++ b/vcpkg/users/buildsystems/snippets/cmake-integration/CMakePresets.json
@@ -1,9 +1,11 @@
 {
-    "version": 3,
-    "configurePresets": [
-        {
-            "name": "debug",
-            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-        }
-    ]
+  "version": 1,
+  "configurePresets": [
+    {
+      "name": "debug",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    }
+  ]
 }

--- a/vcpkg/users/buildsystems/snippets/cmake-integration/CMakePresets.json
+++ b/vcpkg/users/buildsystems/snippets/cmake-integration/CMakePresets.json
@@ -1,5 +1,6 @@
 {
-  "version": 1,
+  "version": 2,
+
   "configurePresets": [
     {
       "name": "debug",

--- a/vcpkg/users/buildsystems/snippets/cmake-integration/CMakeUserPresets.json
+++ b/vcpkg/users/buildsystems/snippets/cmake-integration/CMakeUserPresets.json
@@ -1,9 +1,12 @@
 {
-    "version": 3,
-    "configurePresets": [
-        {
-            "name": "debug",
-            "toolchainFile": "C:/src/vcpkg/scripts/buildsystems/vcpkg.cmake"
-        }
-    ]
+  "version": 1,
+  "configurePresets": [
+    {
+      "name": "debug",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    }
+  ]
 }
+  

--- a/vcpkg/users/buildsystems/snippets/cmake-integration/CMakeUserPresets.json
+++ b/vcpkg/users/buildsystems/snippets/cmake-integration/CMakeUserPresets.json
@@ -1,5 +1,6 @@
 {
-  "version": 1,
+  "version": 2,
+
   "configurePresets": [
     {
       "name": "debug",


### PR DESCRIPTION
To make our `CMakePresets.json` sample files we need to make some changes:

* `version` should be 1
* `binaryDir` and `generator` are required fields
* `toolchainFile` is not allowed, instead use `cacheVariables` and set `CMAKE_TOOLCHAIN_FILE`
