### PR TITLE
Modernize README

### DIFF
--- a/vcpkg/commands/integrate.md
+++ b/vcpkg/commands/integrate.md
@@ -53,7 +53,7 @@ Creates a linked NuGet package for MSBuild integration.
 
 See [MSBuild Per-Project Integration](../users/buildsystems/msbuild-integration.md#linked-nuget-package) for more information.
 
-### `vcpkg integrate powershell`
+### <a name="vcpkg-autocompletion"></a> `vcpkg integrate powershell`
 
 - **Windows only**
 

--- a/vcpkg/readme/vcpkg-README.md
+++ b/vcpkg/readme/vcpkg-README.md
@@ -53,23 +53,17 @@ You can also use any editor:
 
 # Use vcpkg
 
-Create a [manifest for your project's dependencies](../consume/manifest-mode.md)
-(`vcpkg.json`):
+Create a [manifest for your project's dependencies](../consume/manifest-mode.md):
 
-```json
-{
-  "name": "my-project",
-  "version": "0.1.0",
-  "dependencies": [
-    "fmt"
-  ]
-}
+```Console
+vcpkg new --application
+vcpkg add port fmt
 ```
 
 Or [install packages throught the command line](../consume/classic-mode.md):
 
 ```Console
-./vcpkg install fmt
+vcpkg install fmt
 ```
 
 Then use one of our available build system integrations for
@@ -83,7 +77,9 @@ Run `vcpkg help [topic]` for details on a specific topic.
 
 # Contribute
 
-vcpkg is an open source project, and is thus built with your contributions. Here are some ways you can contribute:
+vcpkg is an open source project, and is thus built with your contributions. Here
+are some ways you can contribute:
+
 * [Submit issues][contributing:submit-issue] in vcpkg or existing packages
 * [Submit fixes and new Packages][contributing:submit-pr]
 

--- a/vcpkg/readme/vcpkg-README.md
+++ b/vcpkg/readme/vcpkg-README.md
@@ -28,15 +28,7 @@ guide](../contributing/maintainer-guide.md).
 
 # Get started
 
-First, follow the [quick start guide](../get_started/get-started.md).
-
-If a library you need is not present in the vcpkg registry, you can [open an
-issue on the GitHub repository][contributing:submit-issue] where the vcpkg team and
-community can see it, and potentially add the port to vcpkg. Or you can
-[contribute the package yourself](../get_started/get-started-adding-to-registry.md).
-
-After you've gotten vcpkg installed and working, you may wish to add
-[tab completion](../commands/integrate.md#vcpkg-autocompletion) to your shell.
+First, follow one of our quick start guides.
 
 Whether you're using CMake, MSBuild, or any other build system, vcpkg has you covered:
 
@@ -50,6 +42,13 @@ You can also use any editor:
 * [vcpkg with Visual Sudio Code](../get_started/get-started-vscode.md)
 * [vcpkg with
   CLion](<https://www.jetbrains.com/help/clion/package-management.html>)
+
+If a library you need is not present in the vcpkg registry, [open an issue on
+the GitHub repository][contributing:submit-issue] or [contribute the package
+yourself](../get_started/get-started-adding-to-registry.md).
+
+After you've gotten vcpkg installed and working, you may wish to [add
+tab completion to your terminal](../commands/integrate.md#vcpkg-autocompletion).
 
 # Use vcpkg
 
@@ -66,7 +65,7 @@ Or [install packages throught the command line](../consume/classic-mode.md):
 vcpkg install fmt
 ```
 
-Then use one of our available build system integrations for
+Then use one of our available integrations for
 [CMake](../concepts/build-system-integration.md#cmake-integration),
 [MSBuild](../concepts/build-system-integration.md#msbuild-integration) or 
 [other build
@@ -111,7 +110,7 @@ questions or comments.
 
 * Ports: [Microsoft/vcpkg](<https://github.com/microsoft/vcpkg>)
 * Source code: [Microsoft/vcpkg-tool](<https://github.com/microsoft/vcpkg-tool>)
-* Docs: [Documentation](/vcpkg)
+* Docs: [Microsoft Learn | vcpkg](/vcpkg)
 * Website: [vcpkg.io](<https://vcpkg.io>)
 * Email: [vcpkg@microsoft.com](<mailto:vcpkg@microsoft.com>)
 * Discord: [\#include \<C++\>'s Discord server](<https://www.includecpp.org>), in the #🌏vcpkg channel
@@ -122,7 +121,7 @@ questions or comments.
 The code in this repository is licensed under the MIT License. The libraries
 provided by ports are licensed under the terms of their original authors. Where
 available, vcpkg places the associated license(s) in the location
-`installed/<triplet>/share/<port>/copyright`.
+[`installed/<triplet>/share/<port>/copyright`](../contributing/maintainer-guide.md#install-copyright-file).
 
 # Security
 

--- a/vcpkg/readme/vcpkg-README.md
+++ b/vcpkg/readme/vcpkg-README.md
@@ -26,13 +26,12 @@ developers experience.
 This tool and ecosystem are constantly evolving, and we always appreciate
 contributions! Learn how to start contributing with our [packaging
 tutorial](get_started/get-started-adding-to-registry)
-and [maintainer guidelines](contributing/maintainer-guide).
+and [maintainer guide](contributing/maintainer-guide).
 
 # Using vcpkg
 
-Create a [manifest for your project's dependencies](../consume/manifest-mode.md):
-
-`vcpkg.json`
+Create a [manifest for your project's dependencies](../consume/manifest-mode.md)
+(`vpckg.json`):
 
 ```json
 {
@@ -56,19 +55,19 @@ Then use one of our available build system integrations for
 [other build
 systems](../concepts/build-system-integration.md#manual-integration).
 
-For a short description of all available commands, run `vcpkg-help`. Run `vcpkg
-help [topic]` for details on a specific topic.
+For a short description of all available commands, run `vcpkg help`.
+Run `vcpkg help [topic]` for details on a specific topic.
 
 # Getting Started
 
 First, follow the [quick start guide](../get_started/get-started.md).
 
 If a library you need is not present in the vcpkg registry, you can [open an
-issue on the GitHub repo][contributing:submit-issue] where the vcpkg team and
+issue on the GitHub repository][contributing:submit-issue] where the vcpkg team and
 community can see it, and potentially add the port to vcpkg. Or you can
 [contribute the package yourself](get_started/get-started-adding-to-registry).
 
-After you've gotten vcpkg installed and working, you may wish to add 
+After you've gotten vcpkg installed and working, you may wish to add
 [tab completion](../commands/integrate.md#vcpkg-autocompletion) to your shell.
 
 vcpkg has you covered, it doesn't matter what build system you use:
@@ -86,19 +85,20 @@ Or what editor:
 
 # Resources
 
-* GitHub: ports at [Microsoft/vcpkg](<https://github.com/microsoft/vcpkg>), program at [Microsoft/vcpkg-tool](<https://github.com/microsoft/vcpkg-tool>)
-* Slack: [C++ Alliance's Slack server](<https://cppalliance.org/slack/>), in the #vcpkg channel
-* Discord: [\#include \<C++\>'s Discord server](<https://www.includecpp.org>), in the #🌏vcpkg channel
+* Ports: [Microsoft/vcpkg](<https://github.com/microsoft/vcpkg>)
+* Source code: [Microsoft/vcpkg-tool](<https://github.com/microsoft/vcpkg-tool>)
 * Docs: [Documentation](/vcpkg)
 * Website: [vcpkg.io](<https://vcpkg.io>)
 * Email: [vcpkg@microsoft.com](<mailto:vcpkg@microsoft.com>)
+* Discord: [\#include \<C++\>'s Discord server](<https://www.includecpp.org>), in the #🌏vcpkg channel
+* Slack: [C++ Alliance's Slack server](<https://cppalliance.org/slack/>), in the #vcpkg channel
 
 # Contributing
 
 vcpkg is an open source project, and is thus built with your contributions. Here are some ways you can contribute:
 ]
-* [Submit Issues][contributing:submit-issue] in vcpkg or existing packages
-* [Submit Fixes and New Packages][contributing:submit-pr]
+* [Submit issues][contributing:submit-issue] in vcpkg or existing packages
+* [Submit fixes and new Packages][contributing:submit-pr]
 
 Please refer to our [mantainer guide](../contributing/maintainer-guide.md) and
 [packaging tutorial](../get_started/get-started-packaging.md) for more details.

--- a/vcpkg/readme/vcpkg-README.md
+++ b/vcpkg/readme/vcpkg-README.md
@@ -25,8 +25,8 @@ developers experience.
 
 This tool and ecosystem are constantly evolving, and we always appreciate
 contributions! Learn how to start contributing with our [packaging
-tutorial](get_started/get-started-adding-to-registry)
-and [maintainer guide](contributing/maintainer-guide).
+tutorial](../get_started/get-started-adding-to-registry.md) and [maintainer
+guide](../contributing/maintainer-guide.md).
 
 # Using vcpkg
 
@@ -65,7 +65,7 @@ First, follow the [quick start guide](../get_started/get-started.md).
 If a library you need is not present in the vcpkg registry, you can [open an
 issue on the GitHub repository][contributing:submit-issue] where the vcpkg team and
 community can see it, and potentially add the port to vcpkg. Or you can
-[contribute the package yourself](get_started/get-started-adding-to-registry).
+[contribute the package yourself](../get_started/get-started-adding-to-registry.md).
 
 After you've gotten vcpkg installed and working, you may wish to add
 [tab completion](../commands/integrate.md#vcpkg-autocompletion) to your shell.
@@ -82,7 +82,7 @@ Or what editor:
 * [vcpkg with Visual Sudio Code](../get_started/get-started-vscode.md)
 * [vcpkg with
   CLion](<https://www.jetbrains.com/help/clion/package-management.html>)
-
+  
 # Resources
 
 * Ports: [Microsoft/vcpkg](<https://github.com/microsoft/vcpkg>)
@@ -129,7 +129,7 @@ source code and build tools from their official distribution locations. For use
 behind a firewall, the specific access needed will depend on which ports are
 being installed. If you must install it in an "air gapped" environment, consider
 instaling once in a non-"air gapped" environment, populating an [asset
-cache](/vcpkg/users/assetcaching) shared with the otherwise "air gapped"
+cache](../users/assetcaching.md) shared with the otherwise "air gapped"
 environment.
 
 # Telemetry
@@ -141,4 +141,4 @@ collected by Microsoft is anonymous. You can opt-out of telemetry by:
 - passing `--disable-metrics` to vcpkg on the command line
 - setting the `VCPKG_DISABLE_METRICS` environment variable
 
-Read more about vcpkg telemetry at [https://learn.microsoft.com/vcpkg/about/privacy](/vcpkg/about/privacy).
+Read more about vcpkg telemetry at [https://learn.microsoft.com/vcpkg/about/privacy](../about/privacy.md).

--- a/vcpkg/readme/vcpkg-README.md
+++ b/vcpkg/readme/vcpkg-README.md
@@ -75,13 +75,23 @@ systems](../concepts/build-system-integration.md#manual-integration).
 For a short description of all available commands, run `vcpkg help`.
 Run `vcpkg help [topic]` for details on a specific topic.
 
+# Key features
+
+vcpkg offers powerful features for your package management needs:
+
+* [easily integrate with your build system](../concepts/build-system-integration.md)
+* [control the versions of your dependencies](../users/versioning.md)
+* [package and publish your own packages](../concepts/registries.md)
+* [reuse your binary artifacts](../users/binarycaching.md)
+* [enable offline scenarios with asset caching](../concepts/asset-caching.md)
+
 # Contribute
 
 vcpkg is an open source project, and is thus built with your contributions. Here
 are some ways you can contribute:
 
 * [Submit issues][contributing:submit-issue] in vcpkg or existing packages
-* [Submit fixes and new Packages][contributing:submit-pr]
+* [Submit fixes and new packages][contributing:submit-pr]
 
 Please refer to our [mantainer guide](../contributing/maintainer-guide.md) and
 [packaging tutorial](../get_started/get-started-packaging.md) for more details.

--- a/vcpkg/readme/vcpkg-README.md
+++ b/vcpkg/readme/vcpkg-README.md
@@ -1,8 +1,6 @@
 ---
 title: Microsoft/vcpkg README
 description: README for vcpkg registry
-zone_pivot_group_filename: zone-pivot-groups.json
-zone_pivot_groups: shell-selections
 author: JavierMatosD
 ms.author: javiermat
 ms.date: 3/6/2024
@@ -31,7 +29,7 @@ guide](../contributing/maintainer-guide.md).
 # Using vcpkg
 
 Create a [manifest for your project's dependencies](../consume/manifest-mode.md)
-(`vpckg.json`):
+(`vcpkg.json`):
 
 ```json
 {

--- a/vcpkg/readme/vcpkg-README.md
+++ b/vcpkg/readme/vcpkg-README.md
@@ -7,7 +7,7 @@ ms.date: 3/6/2024
 ROBOTS: NOINDEX
 ---
 
-# vcpkg: Overview
+# vcpkg overview
 
 vcpkg is a free and open-source C/C++ package manager maintained by Microsoft
 and the C++ community. 
@@ -26,7 +26,32 @@ contributions! Learn how to start contributing with our [packaging
 tutorial](../get_started/get-started-adding-to-registry.md) and [maintainer
 guide](../contributing/maintainer-guide.md).
 
-# Using vcpkg
+# Get started
+
+First, follow the [quick start guide](../get_started/get-started.md).
+
+If a library you need is not present in the vcpkg registry, you can [open an
+issue on the GitHub repository][contributing:submit-issue] where the vcpkg team and
+community can see it, and potentially add the port to vcpkg. Or you can
+[contribute the package yourself](../get_started/get-started-adding-to-registry.md).
+
+After you've gotten vcpkg installed and working, you may wish to add
+[tab completion](../commands/integrate.md#vcpkg-autocompletion) to your shell.
+
+vcpkg has you covered, it doesn't matter what build system you use:
+
+* [vcpkg with CMake](../get_started/get-started.md)
+* [vcpkg with MSBuild](../get_started/get-started-msbuild.md)
+* [vcpkg with other build systems](../users/buildsystems/manual-integration.md)
+
+Or what editor:
+
+* [vcpkg with Visual Studio](../get_started/get-started-vs.md)
+* [vcpkg with Visual Sudio Code](../get_started/get-started-vscode.md)
+* [vcpkg with
+  CLion](<https://www.jetbrains.com/help/clion/package-management.html>)
+
+# Use vcpkg
 
 Create a [manifest for your project's dependencies](../consume/manifest-mode.md)
 (`vcpkg.json`):
@@ -56,42 +81,7 @@ systems](../concepts/build-system-integration.md#manual-integration).
 For a short description of all available commands, run `vcpkg help`.
 Run `vcpkg help [topic]` for details on a specific topic.
 
-# Getting Started
-
-First, follow the [quick start guide](../get_started/get-started.md).
-
-If a library you need is not present in the vcpkg registry, you can [open an
-issue on the GitHub repository][contributing:submit-issue] where the vcpkg team and
-community can see it, and potentially add the port to vcpkg. Or you can
-[contribute the package yourself](../get_started/get-started-adding-to-registry.md).
-
-After you've gotten vcpkg installed and working, you may wish to add
-[tab completion](../commands/integrate.md#vcpkg-autocompletion) to your shell.
-
-vcpkg has you covered, it doesn't matter what build system you use:
-
-* [vcpkg with CMake](../get_started/get-started.md)
-* [vcpkg with MSBuild](../get_started/get-started-msbuild.md)
-* [vcpkg with other build systems](../users/buildsystems/manual-integration.md)
-
-Or what editor:
-
-* [vcpkg with Visual Studio](../get_started/get-started-vs.md)
-* [vcpkg with Visual Sudio Code](../get_started/get-started-vscode.md)
-* [vcpkg with
-  CLion](<https://www.jetbrains.com/help/clion/package-management.html>)
-  
-# Resources
-
-* Ports: [Microsoft/vcpkg](<https://github.com/microsoft/vcpkg>)
-* Source code: [Microsoft/vcpkg-tool](<https://github.com/microsoft/vcpkg-tool>)
-* Docs: [Documentation](/vcpkg)
-* Website: [vcpkg.io](<https://vcpkg.io>)
-* Email: [vcpkg@microsoft.com](<mailto:vcpkg@microsoft.com>)
-* Discord: [\#include \<C++\>'s Discord server](<https://www.includecpp.org>), in the #🌏vcpkg channel
-* Slack: [C++ Alliance's Slack server](<https://cppalliance.org/slack/>), in the #vcpkg channel
-
-# Contributing
+# Contribute
 
 vcpkg is an open source project, and is thus built with your contributions. Here are some ways you can contribute:
 ]
@@ -111,6 +101,16 @@ questions or comments.
 [contributing:submit-pr]: https://github.com/microsoft/vcpkg/pulls
 [contributing:coc]: https://opensource.microsoft.com/codeofconduct/
 [contributing:coc-faq]: https://opensource.microsoft.com/codeofconduct/
+  
+# Resources
+
+* Ports: [Microsoft/vcpkg](<https://github.com/microsoft/vcpkg>)
+* Source code: [Microsoft/vcpkg-tool](<https://github.com/microsoft/vcpkg-tool>)
+* Docs: [Documentation](/vcpkg)
+* Website: [vcpkg.io](<https://vcpkg.io>)
+* Email: [vcpkg@microsoft.com](<mailto:vcpkg@microsoft.com>)
+* Discord: [\#include \<C++\>'s Discord server](<https://www.includecpp.org>), in the #🌏vcpkg channel
+* Slack: [C++ Alliance's Slack server](<https://cppalliance.org/slack/>), in the #vcpkg channel
 
 # License
 

--- a/vcpkg/readme/vcpkg-README.md
+++ b/vcpkg/readme/vcpkg-README.md
@@ -5,209 +5,110 @@ zone_pivot_group_filename: zone-pivot-groups.json
 zone_pivot_groups: shell-selections
 author: JavierMatosD
 ms.author: javiermat
-ms.date: 10/17/2023
-ms.prod: vcpkg
+ms.date: 3/6/2024
 ROBOTS: NOINDEX
 ---
 
 # vcpkg: Overview
 
-vcpkg helps you manage C and C++ libraries on Windows, Linux and MacOS.
-This tool and ecosystem are constantly evolving, and we always appreciate contributions!
+vcpkg is a free and open-source C/C++ package manager maintained by Microsoft
+and the C++ community. 
 
-If you've never used vcpkg before, or if you're trying to figure out how to use vcpkg,
-check out our [guide to start using vcpkg](../get_started/get-started.md).
+Initially launched in 2016 as a tool for assisting developers in migrating their
+projects to newer versions of Visual Studio, vcpkg has evolved into a
+cross-platform tool used by developers on Windows, macOS, and Linux. vcpkg has a
+large catalog of open-source libraries and enterprise-ready features designed to
+facilitate your development process with support for any build and project
+systems. vcpkg is a C++ tool at heart and is written in C++ with scripts in
+CMake. It is designed from the ground up to address the unique pain points C/C++
+developers experience.
 
-For a short description of all available commands, run `vcpkg help`. Run `vcpkg help [command name]` for help on a specific command.
+This tool and ecosystem are constantly evolving, and we always appreciate
+contributions! Learn how to start contributing with our [packaging
+tutorial](get_started/get-started-adding-to-registry)
+and [maintainer guidelines](contributing/maintainer-guide).
 
-* GitHub: ports at [Microsoft/vcpkg](<https://github.com/microsoft/vcpkg>), program at [Microsoft/vcpkg-tool](<https://github.com/microsoft/vcpkg-tool>)
-* Slack: [C++ Alliance's Slack server](<https://cppalliance.org/slack/>), in the #vcpkg channel
-* Discord: [\#include \<C++\>'s Discord server](<https://www.includecpp.org>), in the #🌏vcpkg channel
-* Docs: [Documentation](/vcpkg)
+# Using vcpkg
+
+Create a [manifest for your project's dependencies](../consume/manifest-mode.md):
+
+`vcpkg.json`
+
+```json
+{
+  "name": "my-project",
+  "version": "0.1.0",
+  "dependencies": [
+    "fmt"
+  ]
+}
+```
+
+Or [install packages throught the command line](../consume/classic-mode.md):
+
+```Console
+./vcpkg install fmt
+```
+
+Then use one of our available build system integrations for
+[CMake](../concepts/build-system-integration.md#cmake-integration),
+[MSBuild](../concepts/build-system-integration.md#msbuild-integration) or 
+[other build
+systems](../concepts/build-system-integration.md#manual-integration).
+
+For a short description of all available commands, run `vcpkg-help`. Run `vcpkg
+help [topic]` for details on a specific topic.
 
 # Getting Started
 
 First, follow the [quick start guide](../get_started/get-started.md).
 
-If a library you need is not present in the vcpkg catalog, you can [open an issue on the GitHub repo][contributing:submit-issue] where the vcpkg team and community can see it, and potentially add the port to vcpkg.
+If a library you need is not present in the vcpkg registry, you can [open an
+issue on the GitHub repo][contributing:submit-issue] where the vcpkg team and
+community can see it, and potentially add the port to vcpkg. Or you can
+[contribute the package yourself](get_started/get-started-adding-to-registry).
 
-After you've gotten vcpkg installed and working, you may wish to add [tab completion](#tab-completionauto-completion) to your shell.
+After you've gotten vcpkg installed and working, you may wish to add 
+[tab completion](../commands/integrate.md#vcpkg-autocompletion) to your shell.
 
-## Quick Start: Windows
+vcpkg has you covered, it doesn't matter what build system you use:
 
-Prerequisites:
-- Windows 7 or newer
-- [Git][getting-started:git]
-- [Visual Studio][getting-started:visual-studio] 2015 Update 3 or greater with the English language pack
+* [vcpkg with CMake](../get_started/get-started.md)
+* [vcpkg with MSBuild](../get_started/get-started-msbuild.md)
+* [vcpkg with other build systems](../users/buildsystems/manual-integration.md)
 
-First, download and bootstrap vcpkg itself; it can be installed anywhere, but generally we recommend using vcpkg as a submodule so the consuming repo can stay self-contained. Alternatively, vcpkg can be installed globally; we recommend somewhere like `C:\src\vcpkg` or `C:\dev\vcpkg`, since otherwise you may run into path issues for some port build systems.
+Or what editor:
 
-```cmd
-> git clone https://github.com/microsoft/vcpkg
-> .\vcpkg\bootstrap-vcpkg.bat
-```
-
-To install the libraries for your project, run:
-
-```cmd
-> .\vcpkg\vcpkg install [packages to install]
-```
-
-Note: This will install x86 libraries by default. To install x64, run:
-
-```cmd
-> .\vcpkg\vcpkg install [package name]:x64-windows
-```
-
-You can also search for the libraries you need with the `search` subcommand:
-
-```cmd
-> .\vcpkg\vcpkg search [search term]
-```
-
-In order to use vcpkg with Visual Studio, run the following command (may require administrator elevation):
-
-```cmd
-> .\vcpkg\vcpkg integrate install
-```
-
-After this, you can now create a New non-CMake Project (or open an existing one). All installed libraries are immediately ready to be `#include`'d and used in your project without additional configuration.
-
-If you're using CMake with Visual Studio, continue [here](../get_started/get-started-vs.md).
-
-In order to use vcpkg with CMake outside of an IDE, you can use the toolchain file:
-
-```cmd
-> cmake -B [build directory] -S . "-DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake"
-> cmake --build [build directory]
-```
-
-With CMake, you will still need to `find_package` and the like to use the libraries. Check out the [getting started with CMake tutorial](../get_started/get-started.md) for more information on using CMake.
-
-## Quick Start: Unix
-
-Prerequisites for Linux:
-- [Git][getting-started:git]
-- [g++][getting-started:linux-gcc] >= 6
-
-Prerequisites for macOS:
-- [Apple Developer Tools][getting-started:macos-dev-tools]
-
-First, download and bootstrap vcpkg itself; it can be installed anywhere, but generally we recommend using vcpkg as a submodule.
-
-```sh
-$ git clone https://github.com/microsoft/vcpkg
-$ ./vcpkg/bootstrap-vcpkg.sh
-```
-
-To install the libraries for your project, run:
-
-```sh
-$ ./vcpkg/vcpkg install [packages to install]
-```
-
-You can also search for the libraries you need with the `search` subcommand:
-
-```sh
-$ ./vcpkg/vcpkg search [search term]
-```
-
-## Installing Linux Developer Tools
-
-Across the different distros of Linux, there are different packages you'll need to install:
-
-- Debian, Ubuntu, popOS, and other Debian-based distributions:
-
-```sh
-$ sudo apt-get update
-$ sudo apt-get install build-essential tar curl zip unzip
-```
-
-- CentOS
-
-```sh
-$ sudo yum install centos-release-scl
-$ sudo yum install devtoolset-7
-$ scl enable devtoolset-7 bash
-```
-
-- Arch Linux based distributions:
-
-```sh
-$ sudo pacman -Syu base-devel curl zip unzip tar cmake ninja
-```
-
-For any other distributions, make sure you're installing g++ 6 or above. If you want to add instructions for your specific distro, [please open a PR][contributing:submit-pr]!
-
-## Installing macOS Developer Tools
-
-On macOS, the only thing you should need to do is run the following in your terminal:
-
-```sh
-$ xcode-select --install
-```
-
-Then follow along with the prompts in the windows that comes up.
-
-You'll then be able to bootstrap vcpkg along with the [quick start guide](#quick-start-unix)
-
-### vcpkg with CLion
-
-Open the Toolchains settings (File > Settings on Windows and Linux, CLion > Preferences on macOS), and go to the CMake settings (Build, Execution, Deployment > CMake). Finally, in `CMake options`, add the following line:
-
-```
--DCMAKE_TOOLCHAIN_FILE=[vcpkg root]/scripts/buildsystems/vcpkg.cmake
-```
-
-You must add this line to each profile.
-
-# Tab-Completion/Auto-Completion
-
-`vcpkg` supports auto-completion of commands, package names, and options in both powershell and bash. To enable tab-completion in the shell of your choice, run:
-
-::: zone pivot="shell-powershell, shell-cmd"
-
-```pwsh
-> .\vcpkg integrate powershell
-```
-
-::: zone-end
-
-::: zone pivot="shell-bash"
-
-```sh
-$ ./vcpkg integrate bash # or zsh
-```
-
-::: zone-end
+* [vcpkg with Visual Studio](../get_started/get-started-vs.md)
+* [vcpkg with Visual Sudio Code](../get_started/get-started-vscode.md)
+* [vcpkg with
+  CLion](<https://www.jetbrains.com/help/clion/package-management.html>)
 
 # Resources
 
-See the [documentation](/vcpkg) for specific walkthroughs, including [getting started with CMake](../get_started/get-started.md), [getting started with Visual Studio](../get_started/get-started-vs.md), and [publishing packages to a private vcpkg registry](../produce/publish-to-a-git-registry.md).
+* GitHub: ports at [Microsoft/vcpkg](<https://github.com/microsoft/vcpkg>), program at [Microsoft/vcpkg-tool](<https://github.com/microsoft/vcpkg-tool>)
+* Slack: [C++ Alliance's Slack server](<https://cppalliance.org/slack/>), in the #vcpkg channel
+* Discord: [\#include \<C++\>'s Discord server](<https://www.includecpp.org>), in the #🌏vcpkg channel
+* Docs: [Documentation](/vcpkg)
+* Website: [vcpkg.io](<https://vcpkg.io>)
+* Email: [vcpkg@microsoft.com](<mailto:vcpkg@microsoft.com>)
 
-We really appreciate any and all feedback! You can submit an issue in https://github.com/vcpkg/vcpkg.github.io/issues.
-
-See a 4 minute [video demo](https://www.youtube.com/watch?v=y41WFKbQFTw).
-
-[getting-started:using-a-package]: https://learn.microsoft.com/vcpkg/examples/installing-and-using-packages
-[getting-started:git]: https://git-scm.com/downloads
-[getting-started:cmake-tools]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools
-[getting-started:linux-gcc]: #installing-linux-developer-tools
-[getting-started:macos-dev-tools]: #installing-macos-developer-tools
-[getting-started:macos-brew]: #installing-gcc-on-macos
-[getting-started:macos-gcc]: #installing-gcc-on-macos
-[getting-started:visual-studio]: https://visualstudio.microsoft.com/
 # Contributing
 
-Vcpkg is an open source project, and is thus built with your contributions. Here are some ways you can contribute:
-
+vcpkg is an open source project, and is thus built with your contributions. Here are some ways you can contribute:
+]
 * [Submit Issues][contributing:submit-issue] in vcpkg or existing packages
 * [Submit Fixes and New Packages][contributing:submit-pr]
 
-Please refer to our [Contributing Guide](../contributing/maintainer-guide.md) for more details.
+Please refer to our [mantainer guide](../contributing/maintainer-guide.md) and
+[packaging tutorial](../get_started/get-started-packaging.md) for more details.
 
-This project has adopted the [Microsoft Open Source Code of Conduct][contributing:coc]. For more information see the [Code of Conduct FAQ][contributing:coc-faq] or email [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
+This project has adopted the [Microsoft Open Source Code of
+Conduct][contributing:coc]. For more information see the [Code of Conduct
+FAQ][contributing:coc-faq] or email
+[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
+questions or comments.
+ 
 [contributing:submit-issue]: https://github.com/microsoft/vcpkg/issues/new/choose
 [contributing:submit-pr]: https://github.com/microsoft/vcpkg/pulls
 [contributing:coc]: https://opensource.microsoft.com/codeofconduct/
@@ -215,17 +116,29 @@ This project has adopted the [Microsoft Open Source Code of Conduct][contributin
 
 # License
 
-The code in this repository is licensed under the MIT License. The libraries provided by ports are licensed under the terms of their original authors. Where available, vcpkg places the associated license(s) in the location `installed/<triplet>/share/<port>/copyright`.
+The code in this repository is licensed under the MIT License. The libraries
+provided by ports are licensed under the terms of their original authors. Where
+available, vcpkg places the associated license(s) in the location
+`installed/<triplet>/share/<port>/copyright`.
 
 # Security
 
-Most ports in vcpkg build the libraries in question using the original build system preferred by the original developers of those libraries, and download source code and build tools from their official distribution locations. For use behind a firewall, the specific access needed will depend on which ports are being installed. If you must install it in an "air gapped" environment, consider instaling once in a non-"air gapped" environment, populating an [asset cache](/vcpkg/users/assetcaching) shared with the otherwise "air gapped" environment.
+Most ports in vcpkg build the libraries in question using the original build
+system preferred by the original developers of those libraries, and download
+source code and build tools from their official distribution locations. For use
+behind a firewall, the specific access needed will depend on which ports are
+being installed. If you must install it in an "air gapped" environment, consider
+instaling once in a non-"air gapped" environment, populating an [asset
+cache](/vcpkg/users/assetcaching) shared with the otherwise "air gapped"
+environment.
 
 # Telemetry
 
-vcpkg collects usage data in order to help us improve your experience. The data collected by Microsoft is anonymous. You can opt-out of telemetry by
-- running the bootstrap-vcpkg script with -disableMetrics
-- passing --disable-metrics to vcpkg on the command line
-- setting the VCPKG_DISABLE_METRICS environment variable
+vcpkg collects usage data in order to help us improve your experience. The data
+collected by Microsoft is anonymous. You can opt-out of telemetry by:
+
+- running the bootstrap-vcpkg script with `-disableMetrics`
+- passing `--disable-metrics` to vcpkg on the command line
+- setting the `VCPKG_DISABLE_METRICS` environment variable
 
 Read more about vcpkg telemetry at [https://learn.microsoft.com/vcpkg/about/privacy](/vcpkg/about/privacy).

--- a/vcpkg/readme/vcpkg-README.md
+++ b/vcpkg/readme/vcpkg-README.md
@@ -38,13 +38,13 @@ community can see it, and potentially add the port to vcpkg. Or you can
 After you've gotten vcpkg installed and working, you may wish to add
 [tab completion](../commands/integrate.md#vcpkg-autocompletion) to your shell.
 
-vcpkg has you covered, it doesn't matter what build system you use:
+Whether you're using CMake, MSBuild, or any other build system, vcpkg has you covered:
 
 * [vcpkg with CMake](../get_started/get-started.md)
 * [vcpkg with MSBuild](../get_started/get-started-msbuild.md)
 * [vcpkg with other build systems](../users/buildsystems/manual-integration.md)
 
-Or what editor:
+You can also use any editor:
 
 * [vcpkg with Visual Studio](../get_started/get-started-vs.md)
 * [vcpkg with Visual Sudio Code](../get_started/get-started-vscode.md)
@@ -84,7 +84,6 @@ Run `vcpkg help [topic]` for details on a specific topic.
 # Contribute
 
 vcpkg is an open source project, and is thus built with your contributions. Here are some ways you can contribute:
-]
 * [Submit issues][contributing:submit-issue] in vcpkg or existing packages
 * [Submit fixes and new Packages][contributing:submit-pr]
 


### PR DESCRIPTION
Modernize README

* Use same overview as in docs website
* Add new usage section
* Remove quick start sections and link to getting started articles instead

Preview here: https://review.learn.microsoft.com/en-us/vcpkg/readme/vcpkg-readme?branch=pr-en-us-286