### PR TITLE
Update installation-tree-layout.md - update tools/<port> instructions

### DIFF
--- a/vcpkg/reference/installation-tree-layout.md
+++ b/vcpkg/reference/installation-tree-layout.md
@@ -150,6 +150,9 @@ build configurations.
 > vcpkg is first and foremost a C++ library dependency manager. Port authors should
 > be deliberate when deciding to include tools in the installation output. For example:
 > consider installing only a release executable when the debug tool is not needed.
+>
+> Both release and debug executables should be provided when the executables are intended
+> for runtime use.
 
 Contains executable tools produced by a port. It is highly recommended,
 but not required, that each installed executable goes into a subdirectory


### PR DESCRIPTION
Make it clear that in cases where the executables will be used at runtime then both release and debug versions should be included. This is important in general, but for practical reasons especially with dynamic linking. Application developers should be able to copy the right version of the tool to the bin/ folder in the install prefix and have it work with both release and debug builds.