### PR TITLE
Fix inaccessible links

### DIFF
--- a/vcpkg/commands/add-version.md
+++ b/vcpkg/commands/add-version.md
@@ -18,7 +18,7 @@ vcpkg x-add-version [port-name] [options] [--all] [--overwrite-version] [--skip-
 
 ## Description
 
-The `x-add-version` command updates the [version database](..\users\versioning.concepts.md#acquiring-port-versions) for vcpkg ports. By default, it operates on a specified port. With the appropriate switches, users can choose to process all ports or change the default behavior regarding formatting checks and version updates.
+The `x-add-version` command updates the [version database](../users/versioning.concepts.md#acquiring-port-versions) for vcpkg ports. By default, it operates on a specified port. With the appropriate switches, users can choose to process all ports or change the default behavior regarding formatting checks and version updates.
 
 To use the command:
 
@@ -37,7 +37,7 @@ Specifies the name of the port to be updated. If not provided, the user should u
 
 ### `--all`
 
-Processes all the ports in the [built-in](..\maintainers\registries.md#builtin-registries) `ports` directory.
+Processes all the ports in the [built-in](../maintainers/registries.md#builtin-registries) `ports` directory.
 
 ### `--overwrite-version`
 
@@ -54,7 +54,7 @@ Skips the check for proper formatting in the manifest file (`vcpkg.json`) of the
 
 ### `--skip-version-format-check`
 
-Skips the version format check. By default, versions are checked to ensure they adhere to a specific [format](..\users\versioning.md#version-schemes).
+Skips the version format check. By default, versions are checked to ensure they adhere to a specific [format](../users/versioning.md#version-schemes).
 
 ### `--verbose`
 

--- a/vcpkg/commands/create.md
+++ b/vcpkg/commands/create.md
@@ -23,7 +23,7 @@ This command downloads the source code from the provided URL and then creates a 
 
 The command can save the downloaded source code using a specific file name, provided as an optional argument. If the archive file name isn't specified, the command derives a file name from its URL.
 
-It's important to understand that the port created by the `vcpkg create` command serves merely as a starting point and, in most cases, further edits are necessary for a successful build. For more guidance on adding ports to the vcpkg curated catalog, we recommend referring to one of our [tutorials](..\examples\packaging-zipfiles.md)
+It's important to understand that the port created by the `vcpkg create` command serves merely as a starting point and, in most cases, further edits are necessary for a successful build. For more guidance on adding ports to the vcpkg curated catalog, we recommend referring to one of our [tutorials](../examples/packaging-zipfiles.md)
 
 ## Example
 

--- a/vcpkg/get_started/get-started-msbuild.md
+++ b/vcpkg/get_started/get-started-msbuild.md
@@ -146,7 +146,7 @@ Navigate to the Project Properties pages of your project. Under **Configuration 
     Screenshot of enabling vcpkg manifest mode in Visual Studio Project Properties
 :::image-end:::
 
-Other settings, such as [triplets](..\users\triplets.md), are filled in with default values vcpkg detects from your project and will be useful when configuring your project. 
+Other settings, such as [triplets](../users/triplets.md), are filled in with default values vcpkg detects from your project and will be useful when configuring your project. 
 
 ## 5 - Build and run the project
 

--- a/vcpkg/get_started/get-started-msbuild.md
+++ b/vcpkg/get_started/get-started-msbuild.md
@@ -175,6 +175,6 @@ If MSBuild detects a `vcpkg.json` file and manifests are enabled in your project
 
 To learn more about `vcpkg.json` and vcpkg MSBuild integration, see our reference documentation:
 
-- [vcpkg.json](..\reference\vcpkg-json.md)
-- [manifest](..\concepts\manifest-mode.md)
-- [vcpkg in MSBuild projects](..\users\buildsystems\msbuild-integration.md)
+- [vcpkg.json](../reference/vcpkg-json.md)
+- [manifest](../concepts/manifest-mode.md)
+- [vcpkg in MSBuild projects](../users/buildsystems/msbuild-integration.md)

--- a/vcpkg/get_started/get-started-vs.md
+++ b/vcpkg/get_started/get-started-vs.md
@@ -181,5 +181,5 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
 
 To learn more about `vcpkg.json`, see our reference documentation:
 
-- [vcpkg.json](..\reference\vcpkg-json.md)
-- [manifest](..\concepts\manifest-mode.md)
+- [vcpkg.json](../reference/vcpkg-json.md)
+- [manifest](../concepts/manifest-mode.md)

--- a/vcpkg/get_started/get-started-vscode.md
+++ b/vcpkg/get_started/get-started-vscode.md
@@ -226,5 +226,5 @@ Hello World!
 To learn more about `vcpkg.json`, see our reference documentation:
 
 - [Packaging a library](get-started-packaging.md)
-- [vcpkg.json](..\reference\vcpkg-json.md)
-- [manifest](..\concepts\manifest-mode.md)
+- [vcpkg.json](../reference/vcpkg-json.md)
+- [manifest](../concepts/manifest-mode.md)

--- a/vcpkg/get_started/get-started.md
+++ b/vcpkg/get_started/get-started.md
@@ -178,5 +178,5 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
 To learn more about `vcpkg.json`, see our reference documentation:
 
 - [Packaging a library](get-started-packaging.md)
-- [vcpkg.json](..\reference\vcpkg-json.md)
-- [manifest](..\concepts\manifest-mode.md)
+- [vcpkg.json](../reference/vcpkg-json.md)
+- [manifest](../concepts/manifest-mode.md)


### PR DESCRIPTION
Fix inaccessible links in [get_started/](https://github.com/microsoft/vcpkg-docs/tree/main/vcpkg/get_started) and [commands/](https://github.com/microsoft/vcpkg-docs/tree/main/vcpkg/commands):

```
- [vcpkg.json](..\reference\vcpkg-json.md)
- [manifest](..\concepts\manifest-mode.md)
- [vcpkg in MSBuild projects](..\users\buildsystems\msbuild-integration.md)
```

The access results are as follows:
![image](https://github.com/microsoft/vcpkg-docs/assets/110024546/b44677ea-f41d-49ab-9c25-822805b05053)
