### PR TITLE
Add note about environment variables being "session-only"

### DIFF
--- a/includes/env-vars-bash.md
+++ b/includes/env-vars-bash.md
@@ -1,0 +1,5 @@
+> [!NOTE]
+> Setting environment variables using the `export` command only
+> affects the current shell session. To make this change permanent across
+> sessions, you'll need to add the `export` command to your shell's profile
+> script (e.g., `~/.bashrc` or `~/.zshrc`).

--- a/includes/env-vars-bash.md
+++ b/includes/env-vars-bash.md
@@ -1,5 +1,5 @@
 > [!NOTE]
 > Setting environment variables using the `export` command only
 > affects the current shell session. To make this change permanent across
-> sessions, you'll need to add the `export` command to your shell's profile
+> sessions, add the `export` command to your shell's profile
 > script (e.g., `~/.bashrc` or `~/.zshrc`).

--- a/includes/env-vars.md
+++ b/includes/env-vars.md
@@ -1,4 +1,4 @@
 > [!NOTE]
 > Setting environment variables in this manner only affects the current terminal
 > session. To make these changes permanent across all sessions, set them through
-> the Windows' System Environment Variables panel.
+> the Windows System Environment Variables panel.

--- a/includes/env-vars.md
+++ b/includes/env-vars.md
@@ -1,0 +1,4 @@
+> [!NOTE]
+> Setting environment variables in this manner only affects the current terminal
+> session. To make these changes permanent across all sessions, set them through
+> the Windows' System Environment Variables panel.

--- a/vcpkg/get_started/get-started-msbuild.md
+++ b/vcpkg/get_started/get-started-msbuild.md
@@ -71,6 +71,9 @@ All MSBuild C++ projects can now #include any installed libraries. Linking will 
     :::image type="complex" source="../resources/get_started/visual-studio-environment-variable-setup-powershell.png" alt-text="setting up your environment variables":::
         Screenshot of Visual Studio UI for the built-in PowerShell developer window showing how to set up VCPKG_ROOT and and add it to PATH.
     :::image-end:::
+
+    [!INCLUDE [experimental](../../includes/env-vars.md)]
+
     ::: zone-end
     ::: zone pivot="shell-cmd"
     Open the Developer command prompt in Visual Studio.
@@ -89,6 +92,9 @@ All MSBuild C++ projects can now #include any installed libraries. Linking will 
     :::image type="complex" source="../resources/get_started/visual-studio-environment-variable-setup-cmd.png" alt-text="setting up your environment variables":::
         Screenshot of Visual Studio developer command prompt showing how to set up VCPKG_ROOT and and add it to PATH.
     :::image-end:::
+
+    [!INCLUDE [experimental](../../includes/env-vars.md)]
+    
     ::: zone-end
 
     Setting `VCPKG_ROOT` helps Visual Studio locate your vcpkg instance.

--- a/vcpkg/get_started/get-started-msbuild.md
+++ b/vcpkg/get_started/get-started-msbuild.md
@@ -72,7 +72,7 @@ All MSBuild C++ projects can now #include any installed libraries. Linking will 
         Screenshot of Visual Studio UI for the built-in PowerShell developer window showing how to set up VCPKG_ROOT and and add it to PATH.
     :::image-end:::
 
-    [!INCLUDE [experimental](../../includes/env-vars.md)]
+    [!INCLUDE [env-vars](../../includes/env-vars.md)]
 
     ::: zone-end
     ::: zone pivot="shell-cmd"
@@ -93,7 +93,7 @@ All MSBuild C++ projects can now #include any installed libraries. Linking will 
         Screenshot of Visual Studio developer command prompt showing how to set up VCPKG_ROOT and and add it to PATH.
     :::image-end:::
 
-    [!INCLUDE [experimental](../../includes/env-vars.md)]
+    [!INCLUDE [env-vars](../../includes/env-vars.md)]
     
     ::: zone-end
 

--- a/vcpkg/get_started/get-started-packaging.md
+++ b/vcpkg/get_started/get-started-packaging.md
@@ -45,7 +45,7 @@ export VCPKG_ROOT=/path/to/vcpkg
 export PATH=$VCPKG_ROOT:$PATH
 ```
 
-[!INCLUDE [experimental](../../includes/env-vars-bash.md)]
+[!INCLUDE [env-vars](../../includes/env-vars-bash.md)]
 
 ::: zone-end
 ::: zone pivot="shell-cmd"
@@ -55,7 +55,7 @@ set "VCPKG_ROOT=C:\path\to\vcpkg"
 set PATH=%VCPKG_ROOT%;%PATH%
 ```
 
-[!INCLUDE [experimental](../../includes/env-vars.md)]
+[!INCLUDE [env-vars](../../includes/env-vars.md)]
 
 ::: zone-end
 ::: zone pivot="shell-powershell"
@@ -65,7 +65,7 @@ $env:VCPKG_ROOT="C:\path\to\vcpkg"
 $env:PATH="$env:VCPKG_ROOT;$env:PATH"
 ```
 
-[!INCLUDE [experimental](../../includes/env-vars.md)]
+[!INCLUDE [env-vars](../../includes/env-vars.md)]
 
 ::: zone-end
 

--- a/vcpkg/get_started/get-started-packaging.md
+++ b/vcpkg/get_started/get-started-packaging.md
@@ -45,11 +45,7 @@ export VCPKG_ROOT=/path/to/vcpkg
 export PATH=$VCPKG_ROOT:$PATH
 ```
 
-> [!NOTE]
-> Setting the `VCPKG_ROOT` environment variable using the `export` command only
-> affects the current shell session. To make this change permanent across
-> sessions, you'll need to add the `export` command to your shell's profile
-> script (e.g., `~/.bashrc` or `~/.zshrc`).
+[!INCLUDE [experimental](../../includes/env-vars-bash.md)]
 
 ::: zone-end
 ::: zone pivot="shell-cmd"
@@ -59,10 +55,7 @@ set "VCPKG_ROOT=C:\path\to\vcpkg"
 set PATH=%VCPKG_ROOT%;%PATH%
 ```
 
-> [!NOTE]
-> Setting the `VCPKG_ROOT` environment variable using the `set` command only
-> affects the current shell session. To make this change permanent across
-> sessions, you can use the `setx` command and restart the shell session.
+[!INCLUDE [experimental](../../includes/env-vars.md)]
 
 ::: zone-end
 ::: zone pivot="shell-powershell"
@@ -72,11 +65,8 @@ $env:VCPKG_ROOT="C:\path\to\vcpkg"
 $env:PATH="$env:VCPKG_ROOT;$env:PATH"
 ```
 
-> [!NOTE]
-> Setting the `VCPKG_ROOT` and updating the `PATH` environment variables in this
-> manner only affects the current PowerShell session. To make these changes
-> permanent across all sessions, you should add them to your PowerShell profile
-> or set them through the Windows System Environment Variables panel.
+[!INCLUDE [experimental](../../includes/env-vars.md)]
+
 ::: zone-end
 
 Setting `VCPKG_ROOT` tells vcpkg where your vcpkg instance is located.

--- a/vcpkg/get_started/get-started-vs.md
+++ b/vcpkg/get_started/get-started-vs.md
@@ -58,7 +58,7 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
         Screenshot of Visual Studio UI for the built-in PowerShell developer window showing how to set up VCPKG_ROOT and and add it to PATH.
     :::image-end:::
 
-    [!INCLUDE [experimental](../../includes/env-vars.md)]
+    [!INCLUDE [env-vars](../../includes/env-vars.md)]
 
     ::: zone-end
     ::: zone pivot="shell-cmd"
@@ -79,7 +79,7 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
         Screenshot of Visual Studio developer command prompt showing how to set up VCPKG_ROOT and and add it to PATH.
     :::image-end:::
 
-    [!INCLUDE [experimental](../../includes/env-vars.md)]
+    [!INCLUDE [env-vars](../../includes/env-vars.md)]
 
     ::: zone-end
 

--- a/vcpkg/get_started/get-started-vs.md
+++ b/vcpkg/get_started/get-started-vs.md
@@ -57,6 +57,9 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
     :::image type="complex" source="../resources/get_started/visual-studio-environment-variable-setup-powershell.png" alt-text="setting up your environment variables":::
         Screenshot of Visual Studio UI for the built-in PowerShell developer window showing how to set up VCPKG_ROOT and and add it to PATH.
     :::image-end:::
+
+    [!INCLUDE [experimental](../../includes/env-vars.md)]
+
     ::: zone-end
     ::: zone pivot="shell-cmd"
     Open the Developer command prompt in Visual Studio.
@@ -75,6 +78,9 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
     :::image type="complex" source="../resources/get_started/visual-studio-environment-variable-setup-cmd.png" alt-text="setting up your environment variables":::
         Screenshot of Visual Studio developer command prompt showing how to set up VCPKG_ROOT and and add it to PATH.
     :::image-end:::
+
+    [!INCLUDE [experimental](../../includes/env-vars.md)]
+
     ::: zone-end
 
     Setting `VCPKG_ROOT` helps Visual Studio locate your vcpkg instance.

--- a/vcpkg/get_started/get-started-vscode.md
+++ b/vcpkg/get_started/get-started-vscode.md
@@ -63,7 +63,7 @@ $env:PATH="$env:VCPKG_ROOT;$env:PATH"
   Screenshot of setting up VCPKG_ROOT and adding it to PATH in a Visual Studio Code terminal.
 :::image-end:::
 
-[!INCLUDE [experimental](../../includes/env-vars.md)]
+[!INCLUDE [env-vars](../../includes/env-vars.md)]
 
 ::: zone-end
 ::: zone pivot="shell-cmd"
@@ -73,7 +73,7 @@ set "VCPKG_ROOT=C:\path\to\vcpkg"
 set PATH=%VCPKG_ROOT%;%PATH%
 ```
 
-[!INCLUDE [experimental](../../includes/env-vars.md)]
+[!INCLUDE [env-vars](../../includes/env-vars.md)]
 
 ::: zone-end
 ::: zone pivot="shell-bash"
@@ -83,7 +83,7 @@ export VCPKG_ROOT=/c/path/to/vcpkg
 export PATH=$PATH:$VCPKG_ROOT
 ```
 
-[!INCLUDE [experimental](../../includes/env-vars-bash.md)]
+[!INCLUDE [env-vars](../../includes/env-vars-bash.md)]
 
 ::: zone-end
 

--- a/vcpkg/get_started/get-started-vscode.md
+++ b/vcpkg/get_started/get-started-vscode.md
@@ -63,6 +63,8 @@ $env:PATH="$env:VCPKG_ROOT;$env:PATH"
   Screenshot of setting up VCPKG_ROOT and adding it to PATH in a Visual Studio Code terminal.
 :::image-end:::
 
+[!INCLUDE [experimental](../../includes/env-vars.md)]
+
 ::: zone-end
 ::: zone pivot="shell-cmd"
 
@@ -71,13 +73,17 @@ set "VCPKG_ROOT=C:\path\to\vcpkg"
 set PATH=%VCPKG_ROOT%;%PATH%
 ```
 
+[!INCLUDE [experimental](../../includes/env-vars.md)]
+
 ::: zone-end
 ::: zone pivot="shell-bash"
 
-```console
-VCPKG_ROOT=/c/path/to/vcpkg
-PATH=$PATH:$VCPKG_ROOT
+```bash
+export VCPKG_ROOT=/c/path/to/vcpkg
+export PATH=$PATH:$VCPKG_ROOT
 ```
+
+[!INCLUDE [experimental](../../includes/env-vars-bash.md)]
 
 ::: zone-end
 

--- a/vcpkg/get_started/get-started.md
+++ b/vcpkg/get_started/get-started.md
@@ -43,8 +43,8 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
     export PATH=$VCPKG_ROOT:$PATH
     ```
 
-    > [!NOTE]
-    > Setting the `VCPKG_ROOT` environment variable using the `export` command only affects the current shell session. To make this change permanent across sessions, you'll need to add the `export` command to your shell's profile script (e.g., `~/.bashrc` or `~/.zshrc`).
+
+    [!INCLUDE [experimental](../../includes/env-vars-bash.md)]
 
     ::: zone-end
 
@@ -55,8 +55,8 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
     set PATH=%VCPKG_ROOT%;%PATH%
     ```
 
-    > [!NOTE]
-    > Setting the `VCPKG_ROOT` environment variable using the `set` command only affects the current shell session. To make this change permanent across sessions, you can use the `setx` command and restart the shell session.
+
+    [!INCLUDE [experimental](../../includes/env-vars.md)]
 
     ::: zone-end
     ::: zone pivot="shell-powershell"
@@ -66,8 +66,9 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
     $env:PATH = "$env:VCPKG_ROOT;$env:PATH"
     ```
 
-    > [!NOTE]
-    > Setting the `VCPKG_ROOT` and updating the `PATH` environment variables in this manner only affects the current PowerShell session. To make these changes permanent across all sessions, you should add them to your PowerShell profile or set them through the Windows System Environment Variables panel.
+
+    [!INCLUDE [experimental](../../includes/env-vars.md)]
+    
     ::: zone-end
 
     Setting `VCPKG_ROOT` tells vcpkg where your vcpkg instance is located.

--- a/vcpkg/get_started/get-started.md
+++ b/vcpkg/get_started/get-started.md
@@ -44,7 +44,7 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
     ```
 
 
-    [!INCLUDE [experimental](../../includes/env-vars-bash.md)]
+    [!INCLUDE [env-vars](../../includes/env-vars-bash.md)]
 
     ::: zone-end
 
@@ -56,7 +56,7 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
     ```
 
 
-    [!INCLUDE [experimental](../../includes/env-vars.md)]
+    [!INCLUDE [env-vars](../../includes/env-vars.md)]
 
     ::: zone-end
     ::: zone pivot="shell-powershell"
@@ -67,7 +67,7 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
     ```
 
 
-    [!INCLUDE [experimental](../../includes/env-vars.md)]
+    [!INCLUDE [env-vars](../../includes/env-vars.md)]
     
     ::: zone-end
 


### PR DESCRIPTION
This PR adds a `NOTE` in places where environment variables are set through the use of a command. The note remarks that setting variables in said manner only works for the current terminal session and further steps should be followed to make the setting permanent.