### PR TITLE
docs(get-started): fix simple filename mismatch

### DIFF
--- a/vcpkg/examples/snippets/get-started/CMakeLists.txt
+++ b/vcpkg/examples/snippets/get-started/CMakeLists.txt
@@ -4,6 +4,7 @@ project(HelloWorld)
 
 find_package(fmt CONFIG REQUIRED)
 
-add_executable(HelloWorld helloworld.cpp)
+add_executable(HelloWorld main.cpp)
 
 target_link_libraries(HelloWorld PRIVATE fmt::fmt)
+


### PR DESCRIPTION
This PR fixes a small issues where the filename in the `CMakeLists.txt` snippet it different from the one in the explaining text.

From the filename `snippet/examples/get-started/main.cpp` i figured, that it should be main.cpp.



<img width="930" alt="image" src="https://github.com/microsoft/vcpkg-docs/assets/50153092/2abd0bed-b9e2-4b0a-a1f5-ed0156dc0509">
