### PR TITLE
Update versions of GitHub actions because of theirs deprecation.

### DIFF
--- a/vcpkg/consume/binary-caching-github-actions-cache.md
+++ b/vcpkg/consume/binary-caching-github-actions-cache.md
@@ -38,7 +38,7 @@ available in your workflow. Copy the following step in your workflow file:
 
 ```YAML
 - name: Export GitHub Actions cache environment variables
-  uses: actions/github-script@v6
+  uses: actions/github-script@v7
   with:
     script: |
       core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/vcpkg/github-integration.md
+++ b/vcpkg/github-integration.md
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 

--- a/vcpkg/produce/test-registry-ports-gha.md
+++ b/vcpkg/produce/test-registry-ports-gha.md
@@ -61,7 +61,7 @@ caching](../consume/asset-caching.md) articles.
 ```yml
 steps:
   - name: Enable GitHub Actions Cache backend
-    uses: actions/github-script@v6
+    uses: actions/github-script@v7
     with:
       script: |
         core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -105,7 +105,7 @@ backend to work and should be run before any task that involves vcpkg.
 
 ```yml
 - name: Enable GitHub Actions Cache backend
-  uses: actions/github-script@v6
+  uses: actions/github-script@v7
   with:
   script: |
     core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -256,7 +256,7 @@ jobs:
       shell: bash
 
     - name: Enable GitHub Actions Cache backend
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/vcpkg/users/binarycaching.md
+++ b/vcpkg/users/binarycaching.md
@@ -212,7 +212,7 @@ Adds the GitHub Actions cache as a provider. This binary caching provider is onl
 In order for vcpkg to make use of the GitHub Actions Cache, it needs the Actions Cache URL and Runtime Token. To do this, both values should be exported as environment variables in a workflow step similar to the following:
 
 ```yaml
-- uses: actions/github-script@v6
+- uses: actions/github-script@v7
   with:
     script: |
       core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');


### PR DESCRIPTION
* vcpkg/consume/binary-caching-github-actions-cache.md
  * Update actions/github-script to version 7.
* vcpkg/github-integration.md
  * Update actions/checkout to version 4.
* vcpkg/produce/test-registry-ports-gha.md
  * Update actions/github-script to version 7.
  * Update actions/github-script to version 7.
  * Update actions/github-script to version 7.
* vcpkg/users/binarycaching.md
  * Update actions/github-script to version 7.