### PR TITLE
Add note about why we require all ports in the curated registry be simultaneously installable.

### DIFF
--- a/vcpkg/concepts/package-name-resolution.md
+++ b/vcpkg/concepts/package-name-resolution.md
@@ -198,8 +198,7 @@ registry.
 Overlays are a way to extend vcpkg with additional ports and additional
 triplets, without creating a full registry. Overlays are considered before
 performing any registry lookups or versioning and will replace any builtin
-triplets or ports. See the [overlays
-documentation](../concepts/overlay-ports.md) to learn more.
+triplets or ports. See [overlay ports](../concepts/overlay-ports.md) to learn more.
 
 Overlay settings are evaluated in this order:
 

--- a/vcpkg/contributing/maintainer-guide.md
+++ b/vcpkg/contributing/maintainer-guide.md
@@ -16,7 +16,7 @@ It is intended to serve the role of
 
 ### Ports in the current baseline must be simultaneiously installable
 
-We wish to be able to show downstream customers of libraries in the default registry that the
+We wish to be able to show downstream users of libraries in the default registry that the
 combination of libraries in any given baseline we publish have been tested to work together in at
 least some configurations. Allowing ports to exclude each other breaks the ability to test such
 configurations, as the number of builds necessary for such tests would grow as
@@ -24,7 +24,7 @@ configurations, as the number of builds necessary for such tests would grow as
 there is no way for a port or end user to assert that a dependency is *not* installed in their
 requirements.
 
-If you wish to represent such an alternative situation for customers, consider describing how
+If you wish to represent such an alternative situation for users, consider describing how
 someone can create an [overlay port](../concepts/overlay-ports.md) implementing the alternative
 form with a comment in `portfile.cmake` rather than trying to add additional ports never built in
 the curated registry's continuous integration. For example, see
@@ -130,7 +130,7 @@ This property is checked regularly by continuous integration runs which try to i
 
 ### Add CMake exports in an unofficial- namespace
 
-A core design ideal of vcpkg is to not create "lock-in" for customers. In the build system, there should be no difference between depending on a library from the system, and depending on a library from vcpkg. To that end, we avoid adding CMake exports or targets to existing libraries with "the obvious name", to allow upstreams to add their own official CMake exports without conflicting with vcpkg.
+A core design ideal of vcpkg is to not create "lock-in" for users. In the build system, there should be no difference between depending on a library from the system, and depending on a library from vcpkg. To that end, we avoid adding CMake exports or targets to existing libraries with "the obvious name", to allow upstreams to add their own official CMake exports without conflicting with vcpkg.
 
 To that end, any CMake configs that the port exports, which are not in the upstream library, should have `unofficial-` as a prefix. Any additional targets should be in the `unofficial::<port>::` namespace.
 

--- a/vcpkg/contributing/maintainer-guide.md
+++ b/vcpkg/contributing/maintainer-guide.md
@@ -12,7 +12,7 @@ It is intended to serve the role of
 [Homebrew's Maintainer Guidelines](https://docs.brew.sh/Maintainer-Guidelines), and
 [Homebrew's Formula Cookbook](https://docs.brew.sh/Formula-Cookbook).
 
-## Overall Registry Design Goals
+## Overall registry design goals
 
 ### Ports in the current baseline must be simultaneiously installable
 
@@ -37,7 +37,7 @@ without modifying the curated registry.
 
 ## PR structure
 
-### Make separate Pull Requests per port
+### Make separate pull requests per port
 
 Whenever possible, separate changes into multiple PRs.
 This makes them significantly easier to review and prevents issues with one set of changes from holding up every other change.
@@ -61,7 +61,7 @@ Put another way, the reason for this is to ensure that `vcpkg install Xxx`
 gives the user looking for `Xxx` what they were expecting and not be
 surprised by getting something different.
 
-### Use GitHub Draft PRs
+### Use GitHub draft PRs
 
 GitHub Draft PRs are a great way to get CI or human feedback on work that isn't yet ready to merge.
 Most new PRs should be opened as drafts and converted to normal PRs once the CI passes.
@@ -229,7 +229,7 @@ message(STATUS "This recipe is at ${CMAKE_CURRENT_LIST_DIR}")
 message(STATUS "See the overlay ports documentation at https://github.com/microsoft/vcpkg/blob/master/docs/specifications/ports-overlay.md")
 ```
 
-## Build Techniques
+## Build techniques
 
 ### Do not use vendored dependencies
 
@@ -433,7 +433,7 @@ This helps to keep the size of the vcpkg repository down as well as improves the
 
 The purpose of patching in vcpkg is to enable compatibility with compilers, libraries, and platforms. It is not to implement new features in lieu of following proper Open Source procedure (submitting an Issue/PR/etc).
 
-## Do not build tests/docs/examples by default
+### Do not build tests/docs/examples by default
 
 When submitting a new port, check for any options like `BUILD_TESTS` or `WITH_TESTS` or `POCO_ENABLE_SAMPLES` and ensure the additional binaries are disabled. This minimizes build times and dependencies for the average user.
 

--- a/vcpkg/contributing/maintainer-guide.md
+++ b/vcpkg/contributing/maintainer-guide.md
@@ -16,7 +16,7 @@ It is intended to serve the role of
 
 ### Ports in the current baseline must be installable simultaneously
 
-We wish to be able to show downstream users of libraries in the default registry that the
+We wish to be able to show downstream users of libraries in the curated registry that the
 combination of libraries in any given baseline we publish have been tested to work together in at
 least some configurations. Allowing ports to exclude each other breaks the ability to test such
 configurations, as the number of builds necessary for such tests would grow as

--- a/vcpkg/contributing/maintainer-guide.md
+++ b/vcpkg/contributing/maintainer-guide.md
@@ -14,7 +14,7 @@ It is intended to serve the role of
 
 ## Overall registry design goals
 
-### Ports in the current baseline must be simultaneiously installable
+### Ports in the current baseline must be installable simultaneously
 
 We wish to be able to show downstream users of libraries in the default registry that the
 combination of libraries in any given baseline we publish have been tested to work together in at

--- a/vcpkg/reference/vcpkg-configuration-json.md
+++ b/vcpkg/reference/vcpkg-configuration-json.md
@@ -59,8 +59,8 @@ The example also configures custom overlays for ports and triplets that are pres
 | Name | Type   | Description |
 |------|--------|-------------|
 | [default-registry](#default-registry) | [Registry][] or null | Registry used for all ports without a specific registry |
-| [overlay-ports](#overlay-ports) | string[] | List of paths to use as port overlays |
-| [overlay-triplets](#overlay-triplets) | string[] | List of paths to use as triplet overlays |
+| [overlay-ports](#overlay-ports) | string[] | List of paths to use as overlay ports |
+| [overlay-triplets](#overlay-triplets) | string[] | List of paths to use as overlay triplets |
 | [registries](#registries) | [Registry][][] | Additional registries to use for subsets of ports |
 
 ### <a name="default-registry"></a> `"default-registry"`


### PR DESCRIPTION
Drive-by fix: Consistently use "overlay port(s)" (with a space) rather than "overlay-ports" (with a dash) or "port overlays".