### PR TITLE
Clean up some registries documentation.

### DIFF
--- a/vcpkg/about/faq.md
+++ b/vcpkg/about/faq.md
@@ -59,7 +59,7 @@ We recommend cloning directly from [GitHub](https://github.com/microsoft/vcpkg) 
 
 Yes. Follow [our packaging example](../get_started/get-started-packaging.md) to create your own port and see the [overlay ports](../concepts/overlay-ports.md) and [registries](../concepts/registries.md) documentation to learn how to manage your private ports.
 
-You can take this further by publishing your private libraries into a registry. See the article on [Creating registries](../maintainers/registries.md). A registry is a catalog of ports, similar to the one provided with vcpkg that contains open source libraries.
+You can take this further by publishing your private libraries into a registry. See the article on [Creating registries](../maintainers/registries.md). A registry is a collection of ports, similar to the one provided with vcpkg that contains open source libraries.
 
 ## Can I use a prebuilt private library with this tool?
 

--- a/vcpkg/commands/create.md
+++ b/vcpkg/commands/create.md
@@ -23,7 +23,7 @@ This command downloads the source code from the provided URL and then creates a 
 
 The command can save the downloaded source code using a specific file name, provided as an optional argument. If the archive file name isn't specified, the command derives a file name from its URL.
 
-It's important to understand that the port created by the `vcpkg create` command serves merely as a starting point and, in most cases, further edits are necessary for a successful build. For more guidance on adding ports to the vcpkg curated catalog, we recommend referring to one of our [tutorials](../examples/packaging-zipfiles.md)
+It's important to understand that the port created by the `vcpkg create` command serves merely as a starting point and, in most cases, further edits are necessary for a successful build. For more guidance on adding ports to the vcpkg curated registry, we recommend referring to one of our [tutorials](../examples/packaging-zipfiles.md)
 
 ## Example
 

--- a/vcpkg/concepts/overlay-ports.md
+++ b/vcpkg/concepts/overlay-ports.md
@@ -40,7 +40,7 @@ You can add an overlay port in several ways:
 Given this directory structure:
 
 :::image type="complex" source="../resources/ports-overlay-example.png" alt-text="Example with multiple overlay port directories":::
-Overlay directory named team-ports contains ports sqlite3, rapidjson and curl. Overlay directory named my-ports contains ports sqlite3 and rapidjson. The vcpkg directory contains the default catalog.
+Overlay directory named team-ports contains ports sqlite3, rapidjson and curl. Overlay directory named my-ports contains ports sqlite3 and rapidjson. The vcpkg directory contains the default registry.
 :::image-end:::
 
 Run:

--- a/vcpkg/concepts/registries.md
+++ b/vcpkg/concepts/registries.md
@@ -9,21 +9,24 @@ ms.topic: concept-article
 
 # Registries concepts
 
-Registries are collections of ports and their versions. The current catalog of
-ports in vcpkg are distributed via the registry at
-<https://github.com/Microsoft/vcpkg>. vcpkg lets you create your custom
-registries, which you can make either public or private, and host them in a
-variety of storage providers.
+Registries are collections of ports and their versions. The curated registry is
+the one hosted at <https://github.com/Microsoft/vcpkg>. vcpkg lets you create
+custom registries, which may be hosted by a variety of public or private providers.
 
 There are currently two options to implement your own registries: a Git-based
 registry or a filesystem-based registry.
 
 ## Built-in registry
 
-The built-in registry refers to the main vcpkg registry at
-<https://github.com/Microsoft/vcpkg>. Depending on the vcpkg operation mode, this
-can mean your local clone of the vcpkg repository or the remote repository
-hosted in GitHub.
+The built-in registry refers to the implicit registry typically used in classic
+mode scenarios, and edited directly in the directory `VCPKG_ROOT`.
+
+If vcpkg was acquired using `git clone`, this will refer to the registry in `VCPKG_ROOT` itself,
+and is expected to be a clone of <https://github.com/Microsoft/vcpkg> created before running vcpkg.
+
+Otherwise (vcpkg was acquired using the 'one liner' installer or the 'Visual Studio bundle'),
+this will be equivalent to a git registry with a `"repository"` of
+`"https://github.com/Microsoft/vcpkg"`.
 
 ## Git registries
 

--- a/vcpkg/get_started/overview.md
+++ b/vcpkg/get_started/overview.md
@@ -9,7 +9,7 @@ ms.date: 01/10/2024
 
 # vcpkg overview
 
-vcpkg is a free and open-source C/C++ package manager maintained by Microsoft and the C++ community. Launched in 2016, it helps developers migrate their projects to newer versions of Visual Studio. vcpkg has evolved into a cross-platform tool used by developers on Windows, macOS, and Linux. vcpkg has a large catalog of open-source libraries and enterprise-ready features designed to facilitate your development process with support for any build and project systems. vcpkg is a C++ tool at heart and is written in C++ with scripts in CMake. It is designed from the ground up to address the unique pain points of the C/C++ developer experience.
+vcpkg is a free and open-source C/C++ package manager maintained by Microsoft and the C++ community. Launched in 2016, it helps developers migrate their projects to newer versions of Visual Studio. vcpkg has evolved into a cross-platform tool used by developers on Windows, macOS, and Linux. vcpkg has a large registry of open-source libraries and enterprise-ready features designed to facilitate your development process with support for any build and project systems. vcpkg is a C++ tool at heart and is written in C++ with scripts in CMake. It is designed from the ground up to address the unique pain points of the C/C++ developer experience.
 
 ## Why vcpkg?
 
@@ -46,7 +46,7 @@ vcpkg has a unique way of handling [package versions](../users/versioning.concep
 
 ### Registries
 
-A [registry](../concepts/registries.md) is a catalog of ports and available versions that a vcpkg user can install. vcpkg provides a public registry of open-source libraries by default. You can also create your own registries for customizations, patches, or private libraries.
+A [registry](../concepts/registries.md) is a collection of ports and available versions that a vcpkg user can install. vcpkg provides a public registry of open-source libraries by default. You can also create your own registries for customizations, patches, or private libraries.
 
 ### Asset caching
 
@@ -71,7 +71,7 @@ There are a wide variety of system package managers for Linux, macOS, and Window
 - **Prebuilt packages vs. build from source**: vcpkg can build packages from source based on your custom requirements. There is no need to deal with with prebuilt, pre-compiled packages to get them to work.
 - **Catalog-wide versioning**: vcpkg allows you to depend on a version set of compatible packages, rather than having to micromanage individual package versions. You can still do so as needed, but the default experience is designed to be easy to get started with.
 - **Multiple copies of the same library on one system**: You can have multiple copies of the same dependency installed on the same system with vcpkg, whereas system package managers may install one version to a single, system-wide location. This complicates things when you have multiple projects depending on different versions of a library.
-- **Catalog size**: Because vcpkg is specialized for C/C++, it has a very large C/C++ library catalog in comparison to system package managers, and it is actively maintained. In general, you are more likely to find useful and up to date libraries for C++ development.
+- **Catalog size**: Because vcpkg is specialized for C/C++, it has a very large C/C++ library collection in comparison to system package managers, and it is actively maintained. In general, you are more likely to find useful and up to date libraries for C++ development.
 - **Cross-platform support**: System package managers provide packages locked to a particular system. If you need to target more than one operating system flavor, you'll need to find a different package manager for the second system. In contrast, vcpkg is a cross-platform package manager. So, you simply need to adjust your target builds accordingly.
 
 There are situations where a system package manager absolutely makes sense:

--- a/vcpkg/readme/vcpkg-README.md
+++ b/vcpkg/readme/vcpkg-README.md
@@ -15,7 +15,7 @@ and the C++ community.
 Initially launched in 2016 as a tool for assisting developers in migrating their
 projects to newer versions of Visual Studio, vcpkg has evolved into a
 cross-platform tool used by developers on Windows, macOS, and Linux. vcpkg has a
-large catalog of open-source libraries and enterprise-ready features designed to
+large collection of open-source libraries and enterprise-ready features designed to
 facilitate your development process with support for any build and project
 systems. vcpkg is a C++ tool at heart and is written in C++ with scripts in
 CMake. It is designed from the ground up to address the unique pain points C/C++

--- a/vcpkg/users/binarycaching-troubleshooting.md
+++ b/vcpkg/users/binarycaching-troubleshooting.md
@@ -225,7 +225,7 @@ Compare ABI entries for each package. A entry represents a piece of information 
 
 Port files include port scripts (`portfile.cmake`, `vcpkg.json`), patch files (`*.patch`), or any other file in the ports directory: `ports/<library>/*`.
 
-#### Cause 1: CI or pipeline updated the port catalog
+#### Cause 1: CI or pipeline updated the port registry
 
 Before vcpkg ran in your CI, it cloned the latest vcpkg repository.
 

--- a/vcpkg/users/examples/modify-baseline-to-pin-old-boost.md
+++ b/vcpkg/users/examples/modify-baseline-to-pin-old-boost.md
@@ -11,7 +11,7 @@ This document will teach you how to set versions of meta-packages like `boost` o
 
 ## What is a meta-package?
 
-In vcpkg we call meta-packages to ports that by themselves don't install anything but that instead forward installation to another port or ports. The reasons for these meta-packages to exist are plenty: to install different versions of a library depending on platform or to conveniently install/uninstall a catalog of related packages (Boost and Qt).
+In vcpkg we call meta-packages to ports that by themselves don't install anything but that instead forward installation to another port or ports. The reasons for these meta-packages to exist are plenty: to install different versions of a library depending on platform or to conveniently install/uninstall a collection of related packages (Boost and Qt).
 
 In the case of Boost, it is unlikely that a user requires all of the 140+ Boost libraries in their project. For the sake of convenience, vcpkg splits Boost into multiple sub-packages broken down to individual libraries. By doing so, users can limit the subset of Boost libraries that they depend on.
 

--- a/vcpkg/users/platforms/android.md
+++ b/vcpkg/users/platforms/android.md
@@ -6,7 +6,7 @@ ms.topic: concept-article
 ---
 # Android
 
-The triplets x64-android, arm-neon-android, and arm64-android are tested by vcpkg's public catalog CI.
+The triplets x64-android, arm-neon-android, and arm64-android are tested by vcpkg's curated registry continuous integration.
 
 ## Android Build Requirements
 


### PR DESCRIPTION
* Properly explain what the builtin registry means.
* Ban the word "catalog" to mean "registry".
* Use "curated" rather than "public" to describe https://github.com/microsoft/vcpkg.