### PR TITLE
Fixed example code in triplets.md

### DIFF
--- a/vcpkg/users/triplets.md
+++ b/vcpkg/users/triplets.md
@@ -345,7 +345,7 @@ Example:
 
 ```cmake
 set(VCPKG_LIBRARY_LINKAGE static)
-if(PORT MATCHES "qt5-")
+if(${PORT} MATCHES "qt5-")
     set(VCPKG_LIBRARY_LINKAGE dynamic)
 endif()
 ```


### PR DESCRIPTION
The example CMake code in chapter 'Per-port customization' doesn't correctly reference the `PORT` variable. You usually use the ${VAR} syntax when referencing the content of the variable. While both ways work, because... CMake. I believe the change to be the more correct way to do it and also matches the real live example code you link below.