### PR TITLE
Fixing a dead link to the legacy examples/manifest-mode-cmake.md

### DIFF
--- a/vcpkg/examples/installing-and-using-packages.md
+++ b/vcpkg/examples/installing-and-using-packages.md
@@ -8,7 +8,7 @@ is_archived: true
 # Installing and Using Packages Example: SQLite
 
 > [!NOTE]
-> This old example uses Classic mode, but most developers will be happier with Manifest mode. See [Manifest mode: CMake Example](manifest-mode-cmake.md) for an example of converting to Manifest mode.
+> This old example uses Classic mode, but most developers will be happier with Manifest mode. See [Manifest mode: CMake Example](../consume/manifest-mode.md) for an example of converting to Manifest mode.
 
 - [Step 1: Install](#install)
 - [Step 2: Use](#use)


### PR DESCRIPTION
Hi,

I step into https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/installing-and-using-packages.md at first, when working on the manifest mode.

You added [a nice information box with a link to the manifest mode](https://github.com/microsoft/vcpkg-docs/compare/main...Suisse00:vcpkg-docs:patch-1#diff-097ed58fa300101d31bb14bac8984953ca074f2e353390979c3798a27dbb37b9L11). Unfortunately, the link is now dead.

I found [this file](https://github.com/microsoft/vcpkg-docs/commit/10223921b5dc284af6815635dbd83944d60a4ce2#diff-3fa6f2a8672a06f5c881c8621af9e49f935e65eb99e06ec73d42afe0b1323d7a) that confirm you moved examples/manifest-mode-cmake.md to consume/manifest-mode.md, so I updated the dead link to refer to that new one as well.