### PR TITLE
Miscellaneous fixes

### DIFF
--- a/vcpkg/commands/format-manifest.md
+++ b/vcpkg/commands/format-manifest.md
@@ -16,7 +16,8 @@ vcpkg format-manifest [--all] [--convert-control] [<path>...]
 
 ## Description
 
-Formats manifest (`vcpkg.json`) files and converts control (`CONTROL`) files into the manifest format.
+Formats [manifest (`vcpkg.json`)](../reference/vcpkg-json.md) files
+and converts control (`CONTROL`) files into the manifest format.
 If both `CONTROL` and `vcpkg.json` file are present in the same directory, the command will exit with an error.
 
 ## Examples
@@ -27,16 +28,10 @@ To format a specific manifest or control file:
 vcpkg format-manifest /path/to/vcpkg.json
 ```
 
-To format all manifest files in the ports directory:
+To format all manifest files in the `${VCPKG_ROOT}/ports` directory:
 
 ```console
-To format all manifest files in the built-in `ports` directory:
-```
-
-To convert all `CONTROL` files in the ports directory to `vcpkg.json` format:
-
-```console
-vcpkg format-manifest --all --convert-control
+vcpkg format-manifest --all
 ```
 
 ## Options
@@ -45,8 +40,9 @@ All vcpkg commands support a set of [common options](common-options.md).
 
 ### `--all`
 
-Formats all manifest files in the ports directory.
+Formats all manifest files in the `${VCPKG_ROOT}/ports` directory.
 
 ### `--convert-control`
 
-Converts `CONTROL` files into `vcpkg.json` format when found in the ports directory.
+Converts `CONTROL` files into `vcpkg.json` format when found in the ports
+directory.

--- a/vcpkg/commands/format-manifest.md
+++ b/vcpkg/commands/format-manifest.md
@@ -3,7 +3,7 @@ title: vcpkg format-manifest
 description: Reference for the vcpkg format-manifest command. Formats vcpkg.json files and converts CONTROL files to vcpkg.json format.
 author: JavierMatosD
 ms.author: javiermat
-ms.date: 01/10/2024
+ms.date: 07/16/2024
 ---
 
 # vcpkg format-manifest

--- a/vcpkg/consume/asset-caching.md
+++ b/vcpkg/consume/asset-caching.md
@@ -3,7 +3,7 @@ title: "Tutorial: Set up a vcpkg asset cache"
 description: Learn to set up a local asset cache to mirror download assets.
 author: vicroms
 ms.author: viromer
-ms.date: 01/10/2024
+ms.date: 07/16/2024
 ms.topic: tutorial
 #CustomerIntent: As a beginner vcpkg user, I want to set up a local asset cache to mirror downloaded artifacts
 zone_pivot_group_filename: zone-pivot-groups.json

--- a/vcpkg/consume/asset-caching.md
+++ b/vcpkg/consume/asset-caching.md
@@ -69,7 +69,7 @@ $env:X_VCPKG_ASSET_SOURCES="clear;x-azurl,file://D:/vcpkg/asset-cache,,readwrite
 ::: zone pivot="shell-cmd"
 
 ```console
-set X_VCPKG_ASSET_SOURCES="clear;x-azurl,file://D:/vcpkg/asset-cache,,readwrite"
+set "X_VCPKG_ASSET_SOURCES=clear;x-azurl,file://D:/vcpkg/asset-cache,,readwrite"
 ```
 
 ::: zone-end

--- a/vcpkg/consume/binary-caching-local.md
+++ b/vcpkg/consume/binary-caching-local.md
@@ -72,7 +72,7 @@ $env:VCPKG_BINARY_SOURCES="clear;files,\\remote\shared\vcpkg\binary-cache,read;f
 ::: zone pivot="shell-cmd"
 
 ```console
-set VCPKG_BINARY_SOURCES="clear;files,\\remote\shared\vcpkg\binary-cache,read;files,D:\vcpkg\binary-cache,readwrite"
+set "VCPKG_BINARY_SOURCES=clear;files,\\remote\shared\vcpkg\binary-cache,read;files,D:\vcpkg\binary-cache,readwrite"
 ```
 
 ::: zone-end

--- a/vcpkg/consume/binary-caching-local.md
+++ b/vcpkg/consume/binary-caching-local.md
@@ -3,7 +3,7 @@ title: "Tutorial: Set up a vcpkg binary cache using filesystem directories"
 description: Learn to set up a local binary cache to reduce rebuild times.
 author: vicroms
 ms.author: viromer
-ms.date: 01/10/2024
+ms.date: 7/16/2024
 ms.topic: tutorial
 #CustomerIntent: As a beginner vcpkg user, I want to set up a local binary cache so that I save time on package rebuilds
 zone_pivot_group_filename: zone-pivot-groups.json

--- a/vcpkg/consume/binary-caching-nuget.md
+++ b/vcpkg/consume/binary-caching-nuget.md
@@ -4,7 +4,7 @@ description: This tutorial shows how to set up a vcpkg binary cache using a NuGe
 author: vicroms
 ms.author: viromer
 ms.topic: tutorial
-ms.date: 01/10/2024
+ms.date: 7/16/2024
 zone_pivot_group_filename: zone-pivot-groups.json
 zone_pivot_groups: shell-selections
 ---

--- a/vcpkg/consume/binary-caching-nuget.md
+++ b/vcpkg/consume/binary-caching-nuget.md
@@ -275,13 +275,13 @@ $env:VCPKG_BINARY_SOURCES="clear;nugetconfig,<path to nuget.config>"
 ::: zone pivot="shell-cmd"
 
 ```console
-set VCPKG_BINARY_SOURCES="clear;nuget,<feed url>,readwrite"
+set "VCPKG_BINARY_SOURCES=clear;nuget,<feed url>,readwrite"
 ```
 
 If you're using a `nuget.config` file, instead do:
 
 ```console
-set VCPKG_BINARY_SOURCES="clear;nugetconfig,<path to nuget.config>"
+set "VCPKG_BINARY_SOURCES=clear;nugetconfig,<path to nuget.config>"
 ```
 
 ::: zone-end

--- a/vcpkg/get_started/get-started-msbuild.md
+++ b/vcpkg/get_started/get-started-msbuild.md
@@ -85,7 +85,7 @@ All MSBuild C++ projects can now #include any installed libraries. Linking will 
     Run the following commands:
 
     ```console
-    set VCPKG_ROOT="C:\path\to\vcpkg"
+    set "VCPKG_ROOT=C:\path\to\vcpkg"
     set PATH=%VCPKG_ROOT%;%PATH%
     ```
 

--- a/vcpkg/get_started/get-started-msbuild.md
+++ b/vcpkg/get_started/get-started-msbuild.md
@@ -5,7 +5,7 @@ zone_pivot_group_filename: zone-pivot-groups.json
 zone_pivot_groups: shell-selections
 author: data-queue
 ms.author: danshaw2
-ms.date: 01/10/2024
+ms.date: 7/16/2024
 ms.topic: tutorial
 ---
 

--- a/vcpkg/get_started/get-started-packaging.md
+++ b/vcpkg/get_started/get-started-packaging.md
@@ -6,7 +6,7 @@ zone_pivot_groups: shell-selections
 author: JavierMatosD
 ms.author: javiermat
 ms.topic: tutorial
-ms.date: 01/10/2024
+ms.date: 7/16/2024
 #CustomerIntent: As a beginner C++ developer, I want to learn how to package libraries for vcpkg using custom overlays.
 ---
 

--- a/vcpkg/get_started/get-started-packaging.md
+++ b/vcpkg/get_started/get-started-packaging.md
@@ -187,7 +187,7 @@ C++ library from GitHub using vcpkg.
   GitHub repository.
   - `OUT_SOURCE_PATH SOURCE_PATH`: Sets the directory where the source code will
     be extracted.
-  - `REPO JavierMatosD/vcpkg-sample-library`: The GitHub repository containing
+  - `REPO Microsoft/vcpkg-docs`: The GitHub repository containing
     the source code.
   - `REF "${VERSION}"`: The version of the source code to download.
   - `SHA512 0`: Placeholder for the SHA-512 hash of the source code for

--- a/vcpkg/get_started/get-started-vs.md
+++ b/vcpkg/get_started/get-started-vs.md
@@ -71,7 +71,7 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
     Run the following commands:
 
     ```console
-    set VCPKG_ROOT="C:\path\to\vcpkg"
+    set "VCPKG_ROOT=C:\path\to\vcpkg"
     set PATH=%VCPKG_ROOT%;%PATH%
     ```
 

--- a/vcpkg/get_started/get-started-vs.md
+++ b/vcpkg/get_started/get-started-vs.md
@@ -6,7 +6,7 @@ zone_pivot_groups: shell-selections
 author: JavierMatosD
 ms.author: javiermat
 ms.topic: tutorial
-ms.date: 01/10/2024
+ms.date: 7/16/2024
 #CustomerIntent: As a beginner C++ developer, I want to learn how to install and manage packages using CMake and Visual Studio, so that I can easily set up and maintain C++ projects with necessary dependencies.
 ---
 

--- a/vcpkg/get_started/get-started.md
+++ b/vcpkg/get_started/get-started.md
@@ -50,7 +50,7 @@ This tutorial shows you how to create a C++ "Hello World" program that uses the 
     ::: zone pivot="shell-cmd"
 
     ```console
-    set VCPKG_ROOT="C:\path\to\vcpkg"
+    set "VCPKG_ROOT=C:\path\to\vcpkg"
     set PATH=%VCPKG_ROOT%;%PATH%
     ```
 

--- a/vcpkg/get_started/get-started.md
+++ b/vcpkg/get_started/get-started.md
@@ -6,7 +6,7 @@ zone_pivot_groups: shell-selections
 author: JavierMatosD
 ms.author: javiermat
 ms.topic: tutorial
-ms.date: 07/11/2024
+ms.date: 7/16/2024
 #CustomerIntent: As a beginner C++ developer, I want to learn how to install and manage packages using CMake and vcpkg, so that I can easily set up and maintain C++ projects with necessary dependencies.
 ---
 

--- a/vcpkg/reference/vcpkg-json.md
+++ b/vcpkg/reference/vcpkg-json.md
@@ -1,7 +1,7 @@
 ---
 title: vcpkg.json Reference
 description: Reference documentation for the vcpkg.json file format.
-ms.date: 3/1/2024
+ms.date: 7/16/2024
 ms.topic: reference
 ---
 # vcpkg.json Reference

--- a/vcpkg/reference/vcpkg-json.md
+++ b/vcpkg/reference/vcpkg-json.md
@@ -469,8 +469,8 @@ A Platform Expression is a JSON string which describes when a dependency is requ
 Expressions are built from primitive identifiers, logical operators, and grouping:
 
 - `!<expr>`, `not <expr>` - negation
-- `<expr>|<expr>`, `<expr>||<expr>`, `<expr>,<expr>` - logical OR (the keyword `or` is reserved but not valid in platform expressions)
-- `<expr>&<expr>`, `<expr>&&<expr>`, `<expr> and <expr>` - logical AND
+- `<expr>|<expr>`, `<expr>,<expr>` - logical OR (the keyword `or` is reserved but not valid in platform expressions)
+- `<expr>&<expr>`, `<expr> and <expr>` - logical AND
 - `(<expr>)` - grouping/precedence
 
 The following identifiers are defined based on the [triplet settings](../users/triplets.md) and build configuration:


### PR DESCRIPTION
* Fix bug in tutorials when setting environment variables in CMD that would make the variable contain quotation marks in its value.
* Fix a missing example snippet in `format-manifest.md` and clarify that `--all` option only affects the built-in ports directory (`${VCPKG_ROOT}/ports`). 
* Remove reference to a non-Microsoft repository
* Fix documentation of platform expressions where binary operators `&&` and `||` were stated to be supported when they are not.

Fixes #318, #323, and #350