### PR TITLE
Remove references to external registries

### DIFF
--- a/vcpkg/concepts/manifest-mode.md
+++ b/vcpkg/concepts/manifest-mode.md
@@ -94,7 +94,7 @@ vcpkg can be configured through a `vcpkg-configuration.json` file to add more
   "registries": [
     {
       "kind": "git",
-      "repository": "https://github.com/Microsoft/vcpkg-docs",
+      "repository": "https://github.com/microsoft/vcpkg-docs",
       "reference": "vcpkg-registry",
       "baseline": "768f6a3ad9f9b6c4c2ff390137690cf26e3c3453",
       "packages": [ "beicode", "beison" ]

--- a/vcpkg/concepts/manifest-mode.md
+++ b/vcpkg/concepts/manifest-mode.md
@@ -3,7 +3,7 @@ title: Manifest mode
 description: This article describes vcpkg's manifest mode concepts.
 author: vicroms
 ms.author: viromer
-ms.date: 01/10/2024
+ms.date: 7/22/2024
 ms.topic: concept-article
 
 #CustomerIntent: As a vcpkg user, I want to learn more about manifest mode capabilities
@@ -12,11 +12,11 @@ ms.topic: concept-article
 # What is manifest mode?
 
 vcpkg has two operation modes: [classic mode](classic-mode.md) and manifest
-mode. For most users, we recommned manifest mode.
+mode. For most users, we recommend manifest mode.
 
 Manifest mode uses declarative JSON files to describe metadata about your
-project or package. In any case, the name of this file is
-[`vcpkg.json`](../reference/vcpkg-json.md).
+project or package. Manifest files are required to have the
+[`vcpkg.json`](../reference/vcpkg-json.md) name.
 
 Manifest mode is engaged by running the `vcpkg install` command while there's a
 manifest file (`vcpkg.json`) in the working directory. Read ahead for details on
@@ -94,8 +94,9 @@ vcpkg can be configured through a `vcpkg-configuration.json` file to add more
   "registries": [
     {
       "kind": "git",
-      "repository": "https://github.com/northwindtraders/vcpkg-registry",
-      "baseline": "dacf4de488094a384ca2c202b923ccc097956e0c",
+      "repository": "https://github.com/Microsoft/vcpkg-docs",
+      "reference": "vcpkg-registry",
+      "baseline": "768f6a3ad9f9b6c4c2ff390137690cf26e3c3453",
       "packages": [ "beicode", "beison" ]
     }
   ],

--- a/vcpkg/concepts/package-name-resolution.md
+++ b/vcpkg/concepts/package-name-resolution.md
@@ -38,7 +38,7 @@ prioritizes as follows:
   "registries": [
     {
       "kind": "git",
-      "repository": "https://github.com/Microsoft/vcpkg-docs",
+      "repository": "https://github.com/microsoft/vcpkg-docs",
       "reference": "vcpkg-registry",
       "baseline": "768f6a3ad9f9b6c4c2ff390137690cf26e3c3453",
       "packages": ["bei*"]
@@ -81,7 +81,7 @@ Found the following problems in configuration (path/to/vcpkg-configuration.json)
 $ (a configuration object): warning: Package "bei*" is duplicated.
     First declared in:
         location: $.registries[0].packages[0]
-        registry: https://github.com/Microsoft/vcpkg-docs
+        registry: https://github.com/microsoft/vcpkg-docs
     The following redeclarations will be ignored:
         location: $.registries[1].packages[1]
         registry: https://github.com/vicroms/vcpkg-registry

--- a/vcpkg/concepts/package-name-resolution.md
+++ b/vcpkg/concepts/package-name-resolution.md
@@ -38,8 +38,9 @@ prioritizes as follows:
   "registries": [
     {
       "kind": "git",
-      "repository": "https://github.com/northwindtraders/vcpkg-registry",
-      "baseline": "dacf4de488094a384ca2c202b923ccc097956e0c",
+      "repository": "https://github.com/Microsoft/vcpkg-docs",
+      "reference": "vcpkg-registry",
+      "baseline": "768f6a3ad9f9b6c4c2ff390137690cf26e3c3453",
       "packages": ["bei*"]
     },
     {
@@ -69,7 +70,7 @@ Given this configuration, each package name resolves to:
 
 * `beicode`: from registry `https://github.com/vicroms/vcpkg-registry` (exact
   match on `beicode`)
-* `beison`: from registry `https://github.com/northwindtraders/vcpkg-registry`
+* `beison`: from registry `https://github.com/Microsoft/vcpkg-docs`
   (pattern match on `beison` and declared first in `"registries"` array)
 * `fmt`: from default registry (no matches)
 
@@ -80,7 +81,7 @@ Found the following problems in configuration (path/to/vcpkg-configuration.json)
 $ (a configuration object): warning: Package "bei*" is duplicated.
     First declared in:
         location: $.registries[0].packages[0]
-        registry: https://github.com/northwindtraders/vcpkg-registry
+        registry: https://github.com/Microsoft/vcpkg-docs
     The following redeclarations will be ignored:
         location: $.registries[1].packages[1]
         registry: https://github.com/vicroms/vcpkg-registry

--- a/vcpkg/consume/git-registries.md
+++ b/vcpkg/consume/git-registries.md
@@ -94,7 +94,7 @@ purpose of this tutorial is unnecessary and can be deleted.
 
 The source code references two libraries that are not available in the vcpkg curated registry. In
 order to satisfy these dependencies we need to add
-<https://github.com/Microsoft/vcpkg-docs> as an additional registry.
+<https://github.com/microsoft/vcpkg-docs> as an additional registry.
 
 Modify the contents of `vcpkg-configuration.json` to:
 
@@ -108,7 +108,7 @@ Modify the contents of `vcpkg-configuration.json` to:
   "registries": [
     {
       "kind": "git",
-      "repository": "https://github.com/Microsoft/vcpkg-docs",
+      "repository": "https://github.com/microsoft/vcpkg-docs",
       "reference": "vcpkg-registry",
       "baseline": "768f6a3ad9f9b6c4c2ff390137690cf26e3c3453",
       "packages": [ "beicode", "beison" ]

--- a/vcpkg/consume/git-registries.md
+++ b/vcpkg/consume/git-registries.md
@@ -94,7 +94,7 @@ purpose of this tutorial is unnecessary and can be deleted.
 
 The source code references two libraries that are not available in the vcpkg curated registry. In
 order to satisfy these dependencies we need to add
-<https://github.com/NorthWindTraders/vcpkg-registry> as an additional registry.
+<https://github.com/Microsoft/vcpkg-docs> as an additional registry.
 
 Modify the contents of `vcpkg-configuration.json` to:
 
@@ -108,8 +108,9 @@ Modify the contents of `vcpkg-configuration.json` to:
   "registries": [
     {
       "kind": "git",
-      "repository": "https://github.com/northwindtraders/vcpkg-registry",
-      "baseline": "dacf4de488094a384ca2c202b923ccc097956e0c",
+      "repository": "https://github.com/Microsoft/vcpkg-docs",
+      "reference": "vcpkg-registry",
+      "baseline": "768f6a3ad9f9b6c4c2ff390137690cf26e3c3453",
       "packages": [ "beicode", "beison" ]
     }
   ]

--- a/vcpkg/maintainers/registries.md
+++ b/vcpkg/maintainers/registries.md
@@ -28,7 +28,7 @@ The basic structure of a registry is:
 As you're following along with this documentation, it may be helpful to have
 a working example to refer to. We've written one and put it here:
 
-[Northwind Traders: vcpkg registry](https://github.com/northwindtraders/vcpkg-registry).
+[Microsoft/vcpkg-docs: vcpkg registry](https://github.com/microsoft/vcpkg-docs/tree/vcpkg-registry).
 
 All git registries must have a `versions/baseline.json` file. This file contains the set of "latest versions" at a certain commit. It is laid out as a top-level object containing only the `"default"` field. This field should contain an object mapping port names to the version which is currently the latest.
 

--- a/vcpkg/reference/vcpkg-configuration-json.md
+++ b/vcpkg/reference/vcpkg-configuration-json.md
@@ -37,7 +37,7 @@ The latest JSON Schema is available at [https://raw.githubusercontent.com/micros
   "registries": [
     {
       "kind": "git",
-      "repository": "https://github.com/Microsoft/vcpkg-docs",
+      "repository": "https://github.com/microsoft/vcpkg-docs",
       "reference": "vcpkg-registry",
       "baseline": "768f6a3ad9f9b6c4c2ff390137690cf26e3c3453",
       "packages": [ "beicode", "beison" ]
@@ -51,7 +51,7 @@ The latest JSON Schema is available at [https://raw.githubusercontent.com/micros
 }
 ```
 
-This example adds a private registry, `https://github.com/Microsoft/vcpkg-docs/tree/vcpkg-registry`, as the source for the libraries `beicode` and `beison`. All other ports are found from an internal mirror of the Curated Catalog hosted at `https://internal/mirror/of/github.com/Microsoft/vcpkg`.
+This example adds a private registry, `https://github.com/microsoft/vcpkg-docs/tree/vcpkg-registry`, as the source for the libraries `beicode` and `beison`. All other ports are found from an internal mirror of the Curated Catalog hosted at `https://internal/mirror/of/github.com/Microsoft/vcpkg`.
 
 The example also configures custom overlays for ports and triplets that are present in the source code repository.
 

--- a/vcpkg/reference/vcpkg-configuration-json.md
+++ b/vcpkg/reference/vcpkg-configuration-json.md
@@ -37,8 +37,9 @@ The latest JSON Schema is available at [https://raw.githubusercontent.com/micros
   "registries": [
     {
       "kind": "git",
-      "repository": "https://github.com/northwindtraders/vcpkg-registry",
-      "baseline": "dacf4de488094a384ca2c202b923ccc097956e0c",
+      "repository": "https://github.com/Microsoft/vcpkg-docs",
+      "reference": "vcpkg-registry",
+      "baseline": "768f6a3ad9f9b6c4c2ff390137690cf26e3c3453",
       "packages": [ "beicode", "beison" ]
     }
   ],
@@ -50,7 +51,7 @@ The latest JSON Schema is available at [https://raw.githubusercontent.com/micros
 }
 ```
 
-This example adds a private registry, `https://github.com/northwindtraders/vcpkg-registry`, as the source for the libraries `beicode` and `beison`. All other ports are found from an internal mirror of the Curated Catalog hosted at `https://internal/mirror/of/github.com/Microsoft/vcpkg`.
+This example adds a private registry, `https://github.com/Microsoft/vcpkg-docs/tree/vcpkg-registry`, as the source for the libraries `beicode` and `beison`. All other ports are found from an internal mirror of the Curated Catalog hosted at `https://internal/mirror/of/github.com/Microsoft/vcpkg`.
 
 The example also configures custom overlays for ports and triplets that are present in the source code repository.
 

--- a/vcpkg/reference/vcpkg-json.md
+++ b/vcpkg/reference/vcpkg-json.md
@@ -280,7 +280,7 @@ Having a `vcpkg-configuration` defined in `vcpkg.json` while also having a `vcpk
       {
         "kind": "git",
         "baseline": "768f6a3ad9f9b6c4c2ff390137690cf26e3c3453",
-        "repository": "https://github.com/Microsoft/vcpkg-docs",
+        "repository": "https://github.com/microsoft/vcpkg-docs",
         "reference": "vcpkg-registry",
         "packages": [ "beicode", "beison" ]
       }

--- a/vcpkg/reference/vcpkg-json.md
+++ b/vcpkg/reference/vcpkg-json.md
@@ -279,8 +279,9 @@ Having a `vcpkg-configuration` defined in `vcpkg.json` while also having a `vcpk
     "registries": [
       {
         "kind": "git",
-        "baseline": "dacf4de488094a384ca2c202b923ccc097956e0c",
-        "repository": "https://github.com/northwindtraders/vcpkg-registry",
+        "baseline": "768f6a3ad9f9b6c4c2ff390137690cf26e3c3453",
+        "repository": "https://github.com/Microsoft/vcpkg-docs",
+        "reference": "vcpkg-registry",
         "packages": [ "beicode", "beison" ]
       }
     ],


### PR DESCRIPTION
Removes references to `northwindtraders/vcpkg-registry` and instead poinst to [`vcpkg-docs:vcpkg-registry`](https://github.com/Microsoft/vcpkg-docs/tree/vcpkg-registry).