### PR TITLE
Clarify that baseline is optional for filesystem registries.

### DIFF
--- a/vcpkg/reference/vcpkg-configuration-json.md
+++ b/vcpkg/reference/vcpkg-configuration-json.md
@@ -95,7 +95,7 @@ Each path in the array must point to a directory of triplet files ([see triplets
 
 | Name | Required | Type   | Description |
 |------|----------|--------|-------------|
-| [baseline](#registry-baseline) | Yes | string | Minimum version constraint on all ports from this registry |
+| [baseline](#registry-baseline) | Git and Builtin Registries | string | Minimum version constraint on all ports from this registry |
 | [kind](#registry-kind) | Yes | string | Type of registry being used |
 | [packages](#registry-packages) | Yes, if not default | string | List of ports to come from this registry |
 | [path](#registry-path) | Filesystem Registry | string | Path to the Filesystem registry |
@@ -118,9 +118,9 @@ The type of registry being used. A string. Required.
 
 The registry-specific identifier for the minimum versions to use from this registry. A string. Required.
 
-For [Git Registries][Git Registry] and for the [Builtin Registry][], it should be a 40-character git commit sha in the registry's repository that contains a `versions/baseline.json`.
+For [Git Registries][Git Registry] and for the [Builtin Registry][], this is a 40-character git commit sha in the registry's repository that contains a `versions/baseline.json`.
 
-For [Filesystem Registries][Filesystem Registry], it can be any valid baseline string that the registry defines.
+For [Filesystem Registries][Filesystem Registry], it can be any valid json property name that the registry defines on its `baseline.json`. If a filesystem registry does not declare a baseline, the value used is `"default"`.
 
 ### <a name="registry-reference"></a> [Registry][]: `"reference"`
 


### PR DESCRIPTION
Related: https://github.com/microsoft/vcpkg/issues/30939