### PR TITLE
Clarify triplet docs

### DIFF
--- a/vcpkg/concepts/triplets.md
+++ b/vcpkg/concepts/triplets.md
@@ -1,5 +1,5 @@
 ---
-title:  Triplets
+title: Triplets
 description: This article explains the concept of triplets in vcpkg and their capabilities.
 author: vicroms
 ms.author: viromer
@@ -27,7 +27,7 @@ settings. See [per-port
 customization](../users/triplets.md#per-port-customization) for how to accomplish this.
 
 vcpkg comes with pre-defined triplets for many common platforms and
-configurations. Run `vcpkg help triplet` to get the list of available in your
+configurations. Run `vcpkg help triplet` to get a list of available triplets in your
 environment.
 
 ## Triplet selection
@@ -59,7 +59,7 @@ community. Because we do not have continuous coverage, port updates may break
 compatibility with community triplets. We gladly accept and review contributions
 that aim to solve issues with these triplets.
 
-When using a community triplet, a message like the following one will be printed
+When using a community triplet, a message like the following will be printed
 during a package installation:
 
 ```console

--- a/vcpkg/concepts/triplets.md
+++ b/vcpkg/concepts/triplets.md
@@ -88,6 +88,9 @@ for a more detailed walkthrough.
 
 [overlay-triplets]: ../commands/common-options.md#overlay-triplets
 
+> [!NOTE]
+> Triplet names may only contain lowercase alphanumberical characters and hyphens.
+
 ## Remarks
 
 The default triplet when running any vcpkg command is `%VCPKG_DEFAULT_TRIPLET%`

--- a/vcpkg/troubleshoot/build-failures.md
+++ b/vcpkg/troubleshoot/build-failures.md
@@ -121,7 +121,7 @@ Steps to reproduce:
 If the required toolchain is installed, vcpkg may have selected an incorrect
 version of Visual Studio where the toolchain is not installed. See the
 [documentation for the Visual Studio selection
-algorithm](../users/triplets.md#VCPKG_VISUAL_STUDIO_PATH) to learn more.
+algorithm](../users/triplets.md#vcpkg_visual_studio_path) to learn more.
 
 Steps to resolve:
 
@@ -129,7 +129,7 @@ Steps to resolve:
   [`VCPKG_PLATFORM_TOOLSET`](../users/triplets.md#vcpkg_platform_toolset) to the
   appropriate version.
 2 - Alternatively, set the
-  [`VCPKG_VISUAL_STUDIO_PATH`](../users/triplets.md#VCPKG_VISUAL_STUDIO_PATH) to
+  [`VCPKG_VISUAL_STUDIO_PATH`](../users/triplets.md#vcpkg_visual_studio_path) to
   your desired Visual Studio instance installation path.
 
 ## Missing system dependencies

--- a/vcpkg/users/config-environment.md
+++ b/vcpkg/users/config-environment.md
@@ -31,7 +31,7 @@ the vcpkg executable is not located within a valid root and the command line swi
 ## VCPKG_VISUAL_STUDIO_PATH
 
 This environment variable can be set to the full path to a Visual Studio instance on the machine. This Visual Studio instance
-will be used if the triplet does not override it via the [`VCPKG_VISUAL_STUDIO_PATH`](triplets.md#VCPKG_VISUAL_STUDIO_PATH) triplet setting.
+will be used if the triplet does not override it via the [`VCPKG_VISUAL_STUDIO_PATH`](triplets.md#vcpkg_visual_studio_path) triplet setting.
 
 Example: `D:\2017`
 

--- a/vcpkg/users/triplets.md
+++ b/vcpkg/users/triplets.md
@@ -33,7 +33,7 @@ Valid options are `dynamic` and `static`.
 
 Specifies the preferred library linkage.
 
-Valid options are `dynamic` and `static`.  Libraries can ignore this setting if
+Valid options are `dynamic` and `static`. Libraries can ignore this setting if
 they do not support the preferred linkage type.
 
 ### VCPKG_BUILD_TYPE
@@ -70,7 +70,7 @@ See also the CMake documentation for
 
 Specifies an alternate CMake toolchain file to use.
 
-This (if set) will override all other compiler detection logic.  By default, a
+This (if set) will override all other compiler detection logic. By default, a
 toolchain file is selected from `scripts/toolchains/` appropriate to the
 platform.
 
@@ -184,7 +184,7 @@ set(VCPKG_HASH_ADDITIONAL_FILES
 
 ### VCPKG_POST_PORTFILE_INCLUDES
 
-A list of cmake files to include after the execution of portfile.cmake.
+A list of CMake files to include after the execution of portfile.cmake.
 
 This field is optional.
 
@@ -216,13 +216,13 @@ documentation for more details.
 
 > [!WARNING]
 > Enabling this option is not recommended since it can lead to ABI
-> incompatibility in restored binary packages.  See the [binary caching
+> incompatibility in restored binary packages. See the [binary caching
 > documentation](../consume/binary-caching-overview.md) to learn more
 
 When this option is set to `TRUE`, `ON`, or `1`, the compiler will not be
 tracked as part of the package abis.
 
-This will cause [Binary Caching](binarycaching.md) to reuse builds from older or
+This will cause [binary caching](binarycaching.md) to reuse builds from older or
 newer compilers.
 
 ## Windows-specific Variables
@@ -234,7 +234,7 @@ process.
 
 On Windows, vcpkg builds packages in a special clean environment that is
 isolated from the current command prompt to ensure build reliability and
-consistency.  This triplet option can be set to a list of additional environment
+consistency. This triplet option can be set to a list of additional environment
 variables that will be added to the clean environment. The values of these
 environment variables will be hashed into the package abi -- to pass through
 environment variables without abi tracking, see
@@ -264,7 +264,7 @@ we walk through the following algorithm:
    environment variable `VCPKG_VISUAL_STUDIO_PATH`, or consider it unset
 1. Determine the setting for `VCPKG_PLATFORM_TOOLSET` from the triplet or
    consider it unset
-1. Gather a list of all pairs of Visual Studio Instances with all toolsets
+1. Gather a list of all pairs of Visual Studio instances with all toolsets
    available in those instances
    - This is ordered first by instance type (Stable, Prerelease, Legacy) and
      then by toolset version (v143, v142, v141, v140)
@@ -281,7 +281,7 @@ set(VCPKG_VISUAL_STUDIO_PATH "C:\\Program Files (x86)\\Microsoft Visual Studio\\
 
 ### VCPKG_PLATFORM_TOOLSET
 
-Specifies the VS-based C/C++ compiler toolchain to use.
+Specifies the Visual Studio-based C/C++ compiler toolchain to use.
 
 See [`VCPKG_VISUAL_STUDIO_PATH`](#VCPKG_VISUAL_STUDIO_PATH) for the full
 selection algorithm.
@@ -297,9 +297,9 @@ Valid settings:
 
 Specifies the detailed MSVC C/C++ compiler toolchain to use.
 
-By default, [`VCPKG_PLATFORM_TOOLSET`] always chooses the latest installed minor
-version of the selected toolset.  If you need more granularity, you can use this
-variable. Specification can be a partial or full version number. Valid values are,
+By default, [`VCPKG_PLATFORM_TOOLSET`](#VCPKG_PLATFORM_TOOLSET) always chooses the latest installed minor
+version of the selected toolset. If you need more granularity, you can use this
+variable. You can specify either a partial or a full version number. Valid values are,
 for example, `14.25` or `14.27.29110`.
 
 ### VCPKG_LOAD_VCVARS_ENV
@@ -351,7 +351,7 @@ For more information about dynamic libraries on macOS, refer to the following li
 ### VCPKG_OSX_DEPLOYMENT_TARGET
 
 Sets the minimum macOS version for compiled binaries. This also changes what
-versions of the macOS platform SDK that CMake will search for. See the CMake
+versions of the macOS platform SDK CMake will search for. See the CMake
 documentation for
 [CMAKE_OSX_DEPLOYMENT_TARGET](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html)
 for more information.
@@ -372,7 +372,7 @@ for more information.
 
 ## Per-port customization
 
-The CMake Macro `PORT` will be set when interpreting the triplet file and can be
+The CMake macro `PORT` will be set when interpreting the triplet file and can be
 used to change settings (such as `VCPKG_LIBRARY_LINKAGE`) on a per-port basis.
 
 Example:
@@ -384,7 +384,7 @@ if(${PORT} MATCHES "qt5-")
 endif()
 ```
 
-This will build all the `qt5-*` libraries as DLLs, but every other library as a
+This will build all the `qt5-*` ports as dynamic libraries, but every other port as a
 static library.
 
 For an example in a real project, see

--- a/vcpkg/users/triplets.md
+++ b/vcpkg/users/triplets.md
@@ -92,6 +92,15 @@ flags:
 - `VCPKG_C_FLAGS_DEBUG`
 - `VCPKG_C_FLAGS_RELEASE`
 
+If you set `VCPKG_CXX_FLAGS`, you also have to set `VCPKG_C_FLAGS`, and vice-versa. 
+The same is true for the configuration-specific flags. These variables accept a 
+space-delimited string of compiler flags:
+
+```cmake
+set(VCPKG_CXX_FLAGS "/wd4996 -D_CRT_SECURE_NO_WARNINGS")
+set(VCPKG_C_FLAGS "/wd4996 -D_CRT_SECURE_NO_WARNINGS")
+```
+
 ### VCPKG_LINKER_FLAGS
 
 Sets additional linker flags to be used while building dynamic libraries and

--- a/vcpkg/users/triplets.md
+++ b/vcpkg/users/triplets.md
@@ -279,7 +279,7 @@ slash:
 set(VCPKG_VISUAL_STUDIO_PATH "C:\\Program Files (x86)\\Microsoft Visual Studio\\Preview\\Community")
 ```
 
-### VCPKG_PLATFORM_TOOLSET
+### <a name="VCPKG_PLATFORM_TOOLSET"></a> VCPKG_PLATFORM_TOOLSET
 
 Specifies the Visual Studio-based C/C++ compiler toolchain to use.
 

--- a/vcpkg/users/triplets.md
+++ b/vcpkg/users/triplets.md
@@ -381,7 +381,7 @@ for more information.
 
 ## Per-port customization
 
-The CMake variable `PORT` will be set when interpreting the triplet file and can be
+The CMake variable `PORT` will be set when interpreting the triplet file. It can be
 used to change settings (such as `VCPKG_LIBRARY_LINKAGE`) on a per-port basis.
 
 Example:

--- a/vcpkg/users/triplets.md
+++ b/vcpkg/users/triplets.md
@@ -381,7 +381,7 @@ for more information.
 
 ## Per-port customization
 
-The CMake macro `PORT` will be set when interpreting the triplet file and can be
+The CMake variable `PORT` will be set when interpreting the triplet file and can be
 used to change settings (such as `VCPKG_LIBRARY_LINKAGE`) on a per-port basis.
 
 Example:

--- a/vcpkg/users/triplets.md
+++ b/vcpkg/users/triplets.md
@@ -253,7 +253,7 @@ without abi tracking.
 
 See [`VCPKG_ENV_PASSTHROUGH`](#vcpkg_env_passthrough).
 
-### <a name="VCPKG_VISUAL_STUDIO_PATH"></a> VCPKG_VISUAL_STUDIO_PATH
+### VCPKG_VISUAL_STUDIO_PATH
 
 Specifies the Visual Studio installation to use.
 
@@ -279,11 +279,11 @@ slash:
 set(VCPKG_VISUAL_STUDIO_PATH "C:\\Program Files (x86)\\Microsoft Visual Studio\\Preview\\Community")
 ```
 
-### <a name="VCPKG_PLATFORM_TOOLSET"></a> VCPKG_PLATFORM_TOOLSET
+### VCPKG_PLATFORM_TOOLSET
 
 Specifies the Visual Studio-based C/C++ compiler toolchain to use.
 
-See [`VCPKG_VISUAL_STUDIO_PATH`](#VCPKG_VISUAL_STUDIO_PATH) for the full
+See [`VCPKG_VISUAL_STUDIO_PATH`](#vcpkg_visual_studio_path) for the full
 selection algorithm.
 
 Valid settings:
@@ -297,7 +297,7 @@ Valid settings:
 
 Specifies the detailed MSVC C/C++ compiler toolchain to use.
 
-By default, [`VCPKG_PLATFORM_TOOLSET`](#VCPKG_PLATFORM_TOOLSET) always chooses the latest installed minor
+By default, [`VCPKG_PLATFORM_TOOLSET`](#vcpkg_platform_toolset) always chooses the latest installed minor
 version of the selected toolset. If you need more granularity, you can use this
 variable. You can specify either a partial or a full version number. Valid values are,
 for example, `14.25` or `14.27.29110`.


### PR DESCRIPTION
- Document triplet naming requirements (Fixes #383)
- Document usage of `VCPKG_CXX_FLAGS` & friends (Fixes https://github.com/microsoft/vcpkg/issues/11621 )
- Fix typos
- Clarify some information
- Resolve inconsistencies