### PR TITLE
Fix duplicated titles

### DIFF
--- a/vcpkg/TOC.yml
+++ b/vcpkg/TOC.yml
@@ -228,10 +228,10 @@
       href: commands/upgrade.md
     - name: vcpkg version
       href: commands/version.md
-  - name: Asset caching
+  - name: Asset caching configuration
     displayName: airgap, offline, source, mirror
     href: users/assetcaching.md
-  - name: Binary caching
+  - name: Binary caching configuration
     displayName: binaries, build
     href: reference/binarycaching.md
   - name: Environment variables
@@ -402,9 +402,9 @@
     href: maintainers/variables.md
   - name: Software Bill of Materials generation
     href: reference/software-bill-of-materials.md
-  - name: Triplets
+  - name: Triplet variables
     href: users/triplets.md
-  - name: Versioning
+  - name: Versioning reference
     href: users/versioning.md
   - name: Deprecated features
     items:

--- a/vcpkg/get_started/get-started-vscode.md
+++ b/vcpkg/get_started/get-started-vscode.md
@@ -60,7 +60,7 @@ dependencies, configure, build, and run a simple application.
   Screenshot of Visual Studio Code Extension view with CMake Tools Extension
   :::image-end:::
 
-## 4 - Setup vcpkg
+## 4 - Set up environment variables
 
 1. Configure the `VCPKG_ROOT` environmental variable.
 

--- a/vcpkg/reference/binarycaching.md
+++ b/vcpkg/reference/binarycaching.md
@@ -1,10 +1,10 @@
 ---
-title: Binary caching reference
+title: Binary caching configuration
 description: Reference documentation for the binary caching configuration syntax.
 ms.date: 5/2/2024
 ms.topic: reference
 ---
-# Binary caching reference
+# Binary caching configuration
 
 ## Configuration Syntax
 

--- a/vcpkg/users/assetcaching.md
+++ b/vcpkg/users/assetcaching.md
@@ -1,12 +1,12 @@
 ---
-title: Asset caching reference
+title: Asset caching configuration
 description: Reference documentation for the asset caching feature configuration and capabilities.
 author: vicroms
 ms.author: viromer
 ms.topic: reference
 ms.date: 01/10/2024
 ---
-# Asset caching reference
+# Asset caching configuration
 
 ## Sources
 

--- a/vcpkg/users/triplets.md
+++ b/vcpkg/users/triplets.md
@@ -1,5 +1,5 @@
 ---
-title: Triplets reference
+title: Triplet variables
 description: This article describes the configurable variables available to triplet files.
 author: vicroms
 ms.author: viromer
@@ -7,7 +7,7 @@ ms.date: 02/14/2024
 ms.topic: reference
 ---
 
-# Triplets reference
+# Triplet variables
 
 This article describes the vcpkg variables that are available to triplet files.
 A triplet file can also include user defined variables.


### PR DESCRIPTION
Fix duplicated titles in table of contents and article headers