### PR TITLE
fix nuget command for `setapikey`

### DIFF
--- a/vcpkg/consume/binary-caching-nuget.md
+++ b/vcpkg/consume/binary-caching-nuget.md
@@ -140,7 +140,7 @@ C:\path\to\nuget.exe setapikey <apikey> -Source <feed url>
 ::: zone pivot="shell-bash"
 
 ```bash
-mono `vcpkg fetch nuget | tail -n 1` sources setapikey <apiKey> -Source <feed url>
+mono `vcpkg fetch nuget | tail -n 1` setapikey <apiKey> -Source <feed url>
 ```
 
 ::: zone-end


### PR DESCRIPTION
There was a `sources` parameter before `setapikey` that shouldn't be there.