### PR TITLE
Update example vcpkg-configuration.json in test-registry-ports-gha.md

### DIFF
--- a/vcpkg/produce/test-registry-ports-gha.md
+++ b/vcpkg/produce/test-registry-ports-gha.md
@@ -168,7 +168,7 @@ registries.
       "kind": "git",
       "repository": "https://github.com/Microsoft/vcpkg",
       "baseline": "42bb0d9e8d4cf33485afb9ee2229150f79f61a1f",
-      "packages": "*"
+      "packages": ["*"]
     }
   ]
 }


### PR DESCRIPTION
As I was following along with this documentation, vcpkg gave an error:

`vcpkg-configuration.json: error: $.registries[0].packages: mismatched type: expected a package pattern array`

It appears packages value must be a JSON array.