### PR TITLE
Improve registries documentation

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,9 +1,20 @@
 {
     "MD013": {
+        "line_length": 120,
         // Increase code block lenght since some command-line examples are extremely long
-        "code_block_line_length": 180
+        "code_blocks": false,
+        "tables": false
+    },
+    // Some documentation sections repeat headings, allow this as long as the parent heading is different
+    "MD024": {
+        "siblings_only": true
     },
     // Disable "Multiple top level headings in the same document" triggered by metadata and top-level
     // heading on articles
-    "MD025": false
+    "MD025": false,
+    // We use inline <a> to simplify anchor links
+    // We use inline <br> for line breaks inside tables
+    "MD033": {
+        "allowed_elements": [ "a", "br" ]
+    } 
 }

--- a/vcpkg/about/faq.md
+++ b/vcpkg/about/faq.md
@@ -32,7 +32,9 @@ There are two ways to manage your dependencies with vcpkg:
 
 ## Can I contribute a new library?
 
-Yes! Start by reading our [contribution guidelines](https://github.com/Microsoft/vcpkg/blob/master/CONTRIBUTING.md). Also take a look at our [Maintainer Guide](../contributing/maintainer-guide.md) which goes into more details. We also have a [tutorial for adding a port to vcpkg](../get_started/get-started-adding-to-registry.md) to help you get started.
+Yes! Start by reading our [contribution guidelines](https://github.com/Microsoft/vcpkg/blob/master/CONTRIBUTING.md). Also
+take a look at our [Maintainer Guide](../contributing/maintainer-guide.md) which goes into more details. We also have a
+[tutorial for adding a port to vcpkg](../get_started/get-started-adding-to-registry.md) to help you get started.
 
 If you want to contribute but don't have a particular library in mind then take a look at the list
 of [new port requests](https://github.com/Microsoft/vcpkg/issues?q=is%3Aissue+is%3Aopen+label%3Acategory%3Anew-port).
@@ -98,7 +100,17 @@ dependencies for individual projects, which works even if multiple projects are
 on the same machine and allow you to easily manage package versions and which
 registries libraries are coming from.
 
-However, if you are using classic mode instead, within a single instance of vcpkg (e.g. one set of `installed\`, `packages\`, `ports\` and so forth), you can only have one version of a library installed (otherwise, the headers would conflict with each other!). For those with experience with system-wide package managers, packages in vcpkg correspond to the `X-dev` or `X-devel` packages. In this case, to use different versions of a library for different projects, we recommend making separate instances of vcpkg and using the per-project integration mechanisms. The versions of each library are specified by the files in `ports\`, so they are easily manipulated using standard `git` commands. This makes it very easy to roll back the entire set of libraries to a consistent set of older versions which all work with each other. If you need to then pin a specific library forward, that is as easy as checking out the appropriate version of `ports\<package>\`. If your application is very sensitive to the versions of libraries, we recommend checking in the specific set of portfiles you need into your source control along with your project sources and using the `--vcpkg-root` option to redirect the working directory of `vcpkg.exe`.
+However, if you are using classic mode instead, within a single instance of vcpkg (e.g. one set of `installed\`,
+`packages\`, `ports\` and so forth), you can only have one version of a library installed (otherwise, the headers would
+conflict with each other!). For those with experience with system-wide package managers, packages in vcpkg correspond
+to the `X-dev` or `X-devel` packages. In this case, to use different versions of a library for different projects, we
+recommend making separate instances of vcpkg and using the per-project integration mechanisms. The versions of each
+library are specified by the files in `ports\`, so they are easily manipulated using standard `git` commands. This
+makes it very easy to roll back the entire set of libraries to a consistent set of older versions which all work with
+each other. If you need to then pin a specific library forward, that is as easy as checking out the appropriate version
+of `ports\<package>\`. If your application is very sensitive to the versions of libraries, we recommend checking in the
+specific set of portfiles you need into your source control along with your project sources and using the `--vcpkg-root`
+option to redirect the working directory of `vcpkg.exe`.
 
 ## How does vcpkg protect my privacy?
 
@@ -120,7 +132,11 @@ Yes. While vcpkg will only produce the standard "Release" and "Debug" configurat
 
 First of all, vcpkg will automatically assume any custom configuration starting with "Release" (resp. "Debug") as a configuration that is compatible with the standard "Release" (resp. "Debug") configuration and will act accordingly.
 
-For other configurations, you only need to override the MSBuild `$(VcpkgConfiguration)` macro in your project file (.vcxproj) to declare the compatibility between your configuration, and the target standard configuration. Unfortunately, due to the sequential nature of MSBuild, you'll need to add those settings much higher in your vcxproj so that it is declared before the vcpkg integration is loaded. It is recommend that the `$(VcpkgConfiguration)` macro is added to the "Globals" PropertyGroup.
+For other configurations, you only need to override the MSBuild `$(VcpkgConfiguration)` macro in your project file
+(.vcxproj) to declare the compatibility between your configuration, and the target standard configuration.
+Unfortunately, due to the sequential nature of MSBuild, you'll need to add those settings much higher in your vcxproj
+so that it is declared before the vcpkg integration is loaded. It is recommend that the `$(VcpkgConfiguration)` macro
+is added to the "Globals" PropertyGroup.
 
 For example, you can add support for your "MyRelease" configuration by adding in your project file:
 

--- a/vcpkg/about/faq.md
+++ b/vcpkg/about/faq.md
@@ -59,7 +59,7 @@ We recommend cloning directly from [GitHub](https://github.com/microsoft/vcpkg) 
 
 Yes. Follow [our packaging example](../get_started/get-started-packaging.md) to create your own port and see the [overlay ports](../concepts/overlay-ports.md) and [registries](../concepts/registries.md) documentation to learn how to manage your private ports.
 
-You can take this further by publishing your private libraries into a registry. See the article on [Creating registries](../maintainers/registries.md). A registry is a collection of ports, similar to the one provided with vcpkg that contains open source libraries.
+You can take this further by publishing your private libraries into a registry. See the article on [Custom registries](../concepts/registries.md). A registry is a collection of ports, similar to the one provided with vcpkg that contains open source libraries.
 
 ## Can I use a prebuilt private library with this tool?
 

--- a/vcpkg/commands/add-version.md
+++ b/vcpkg/commands/add-version.md
@@ -37,7 +37,7 @@ Specifies the name of the port to be updated. If not provided, the user should u
 
 ### `--all`
 
-Processes all the ports in the [built-in](../maintainers/registries.md#builtin-registries) `ports` directory.
+Process all the ports in the [built-in](../concepts/registries.md#built-in-registry) `ports` directory.
 
 ### `--overwrite-version`
 

--- a/vcpkg/concepts/manifest-mode.md
+++ b/vcpkg/concepts/manifest-mode.md
@@ -24,7 +24,7 @@ how to [install packages in manifest mode](#install-manifest-mode).
 
 Manifest mode is also required to use advanced features like
 [versioning](../users/versioning.md) and
-[custom registries](../users/registries.md).
+[custom registries](../concepts/registries.md).
 
 ## Manifest files in ports
 
@@ -79,7 +79,7 @@ feature is not available in classic mode.
 ## Configuration file
 
 vcpkg can be configured through a `vcpkg-configuration.json` file to add more
-[package registries](../users/registries.md) or
+[package registries](../concepts/registries.md) or
 [overlay ports and triplets](../concepts/overlay-ports.md) locations.
 
 ### Configuration file example

--- a/vcpkg/concepts/manifest-mode.md
+++ b/vcpkg/concepts/manifest-mode.md
@@ -61,7 +61,7 @@ resolving features, etc.
 
 The main purpose of using a manifest file in your project is to declare your
 dependencies. When using a project manifest, you're able to specify version
-constraints and overrides to lock specific versions of your dependencies. This 
+constraints and overrides to lock specific versions of your dependencies. This
 feature is not available in classic mode.
 
 ### Project manifest example

--- a/vcpkg/concepts/overlay-ports.md
+++ b/vcpkg/concepts/overlay-ports.md
@@ -70,10 +70,10 @@ To install:
 
 Run:
 
-```
-vcpkg install sqlite3 rapidjson curl
-    --overlay-ports=my-ports/rapidjson
-    --overlay-ports=vcpkg/ports/curl
+```bash
+vcpkg install sqlite3 rapidjson curl \
+    --overlay-ports=my-ports/rapidjson \
+    --overlay-ports=vcpkg/ports/curl \
     --overlay-ports=team-ports
 ```
 

--- a/vcpkg/concepts/overlay-ports.md
+++ b/vcpkg/concepts/overlay-ports.md
@@ -11,7 +11,7 @@ ms.topic: concept-article
 
 Usually, vcpkg ports are obtained from [registries](../concepts/registries.md). It is very likely that most of the ports you install come from the official vcpkg registry at <https://github.com/Microsoft/vcpkg>. vcpkg lets you install ports available to you via the file system, we call these ports, overlay ports.
 
-An overlay port can act as a drop-in replacement for an existing port or as a new port that is otherwise not available in a [registry](../maintainers/registries.md). While [resolving package names](../concepts/package-name-resolution.md), overlay ports take priority.
+An overlay port can act as a drop-in replacement for an existing port or as a new port that is otherwise not available in a [registry](../concepts/registries.md). While [resolving package names](../concepts/package-name-resolution.md), overlay ports take priority.
 
 Overlay ports are evaluated in the following order:
 

--- a/vcpkg/concepts/registries.md
+++ b/vcpkg/concepts/registries.md
@@ -12,8 +12,7 @@ ms.topic: concept-article
 
 vcpkg hosts a selection of libraries packaged into [ports](ports.md) at
 <https://github.com/Microsoft/vcpkg>, this collection of ports is called the
-*curated registry*. However, vcpkg is not limited to just installing ports from
-the curated registry. Users are capable of extending the selection of ports by
+*curated registry*. However, vcpkg is not limited to the curated registry. Users can extend the selection of ports by
 creating custom registries.
 
 A registry is a collection of ports and helper files arranged in a specific
@@ -69,8 +68,8 @@ There are two components to the versions database:
 * the version files.
 
 The baseline file is a JSON file named `baseline.json` located at the root of
-the `versions` directory. The purpose of the baseline file is to describe the
-set of versions that are considered to be the latest for each port in the
+the `versions` directory. The baseline file describes the
+set of versions that are current for each port in the
 registry. The layout of the baseline file depends on the kind of registry.
 
 For each port in the registry, a corresponding _version file_ must exist.
@@ -100,8 +99,7 @@ The purpose of the baseline file is to describe the set of versions that are
 considered to be the latest for all ports in the registry. It is expected that
 this file is updated each time a new version of a port is added to the registry.
 
-The layout of the file is a map of named baselines. With each named baseline
-being itself a map of port names to version entries.
+The file is a JSON file composed of a single object whose properties are named baseline objects. Each baseline object's properties are port names, whose values are version entries.
 
 Each baseline version entry is an object with the following properties:
 
@@ -131,14 +129,13 @@ See the reference documentation for:
 
 ## Version files
 
-Each port in the registry must have a corresponding versions file. The versions
+Each port in the registry has a corresponding versions file. The versions
 file is a JSON file named the same as its corresponding port, for example, a
 port named `foo` must have a corresponding `foo.json` file. 
 
-vcpkg expects the versions files to be stored in the following location
-`versions/<prefix>/<port name>.json` , where `<prefix>` is the first letter of
+Versions files are stored at `versions/<prefix>/<port name>.json` , where `<prefix>` is the first letter of
 the port name followed by a hyphen. For example, the versions file for port
-`foo` must be stored in `versions/f-/foo.json`.
+`foo` is at `versions/f-/foo.json`.
 
 The purpose of the versions file is two-fold:
 
@@ -382,7 +379,7 @@ array](../reference/vcpkg-configuration-json.md#registries).
 **Don't rewrite version history**
 
 Once a version has been pubished to the version database, do not change its
-associated `git-tree`.
+associated `git-tree` in a git registry or directory in a filesystem registry.
 
 One of vcpkg's design principles is that the versions of installed dependencies
 do not change without user intervention. Rewriting the version file history by

--- a/vcpkg/concepts/registries.md
+++ b/vcpkg/concepts/registries.md
@@ -21,10 +21,10 @@ can be installed with the same features
 ([versioning](../users/versioning.md), [binary
 caching](../users/binarycaching.md)) offered to ports in the curated registry.
 
-There are currently three kinds of registries: 
+There are currently three kinds of registries:
 
 * The [built-in registry](#built-in-registry),
-* [Git registries](#git-registries), and 
+* [Git registries](#git-registries), and
 * [filesystem registries](#filesystem-registries).
 
 vcpkg can be instructed to consider ports available in custom registries by
@@ -39,13 +39,13 @@ For vcpkg to interface with a registry, it must conform to the following structu
 
 * A directory named `ports` contains the collection of ports, with each
   subdirectory containing a specific port matching the subdirectory name. For
-  example, the files for port `foo` must be located in `ports/foo`.
-* A directory named `versions` must contain the files that comprise the [versions
+  example, the files for port `foo` is located in `ports/foo`.
+* A directory named `versions` contains the files that comprise the [versions
   database](#versions-database).
   
 ### Example: registry structure
 
-```
+```text
 ports/
   foo/
     portfile.cmake
@@ -59,17 +59,15 @@ versions/
 ## Versions database
 
 All registries contain a `versions` directory at the
-root of the registry which contains the _versions database_.
+root of the registry which contains the *versions database*.
 
 There are two components to the versions database:
 
-* The baseline file 
+* The baseline file
 * The version files
 
 The baseline file is a JSON file named `baseline.json` located at the root of
-the `versions` directory. It describes the
-set of versions that are current for each port in the
-registry. The layout of the baseline file depends on the kind of registry.
+the `versions` directory.
 
 The versions files are JSON files with the same names as the available ports.
 They must exist at `versions/<prefix>/<port name>.json`, where `<prefix>` is
@@ -92,7 +90,9 @@ The purpose of the baseline file is to describe the set of versions that are
 considered to be the latest for all ports in the registry. It is expected that
 this file is updated each time a new version of a port is added to the registry.
 
-The file is a JSON file composed of a single object whose properties are named baseline objects. Each baseline object's properties are port names, whose values are version entries.
+The file is a JSON file composed of a single object whose properties are named baseline objects. Each baseline object's
+properties are port names, whose values are version entries. The [registries reference](../maintainers/registries.md)
+article describes the layout of baseline files in more detail.
 
 Each baseline version entry is an object with the following properties:
 
@@ -134,14 +134,14 @@ The purpose of the versions file is two-fold:
 
 The layout of the versions file is an object containing a `"versions"` array, with
 each entry in that array being a version object.  A version object must contain
-the following properties: 
+the following properties:
 
 * A version property: The property's key and value must match the ones used by
   the port in its `vcpkg.json` file. The key must be one of `version`,
   `version-semver`, `version-date`, or `version-string`; the value must be the
-  version as it appears in the port's manifest file (`vcpkg.json`). 
+  version as it appears in the port's manifest file (`vcpkg.json`).
 * `port-version`: the value is the port's `port-version` as it appears in the
-  port's `vcpkg.json` file. 
+  port's `vcpkg.json` file.
 * `git-tree`: (only on Git registries) the value is the git-tree SHA
   corresponding to the port's directory. This is a SHA calculated by hashing the
   contents of the port's directory; this git-tree SHA can be used by Git to
@@ -174,7 +174,7 @@ the following properties:
     }
   ]
 }
-``` 
+```
 
 See the reference documentation for:
 
@@ -185,11 +185,9 @@ See the reference documentation for:
 
 ## Built-in registry
 
-The built-in registry is a special kind of registry. The built-in registry
-is the default registry used in some operation modes, like [classic
-mode](classic-mode.md). When a [default
-registry](../reference/vcpkg-configuration-json.md#default-registry) is not
-specified, vcpkg implicitly uses the built-in registry.
+The built-in registry is a special kind of registry. It is the default registry used in [classic mode](classic-mode.md).
+In [manifest mode](manifest-mode.md), when a [default registry](../reference/vcpkg-configuration-json.md#default-registry)
+is not specified, vcpkg implicitly uses the built-in registry.
 
 The built-in registry refers to the local copy of the curated
 registry created when you `git clone` the vcpkg repository from
@@ -227,7 +225,8 @@ a new port or a new version to the registry. When adding versions using this
 command there are a couple of things to keep in mind:
 
 > [!IMPORTANT]
-> When adding a new version, always remember to update the port's declared version to one not already published, to avoid rewriting the version history.
+> When adding a new version, always remember to update the port's declared version to one not already published, to avoid
+> rewriting the version history.
 
 When you are making changes to a port, the first step should be to increase its
 version in the `vcpkg.json` file. If your changes include an update to the
@@ -235,13 +234,11 @@ package's [upstream](../concepts/glossary.md#upstream) version, remember to set
 the `port-version` to `0`; otherwise, remember to increase the `port-version` by
 one.
 
-**Port changes must be commited**
-
 The [`x-add-version` command](../commands/add-version.md) requires that all your
 port changes are commited to the repository before updating the version
 database.
 
-**Example: adding a new port version to a Git registry**
+#### Example: adding a new port version to a Git registry
 
 ```Console
 git add ports/foo/.
@@ -269,9 +266,9 @@ filesystem. They follow the common registry structure but don't make use of Git
 to offer versioning capabilities. Instead, they use a primitive form of version
 control using a distinct path for each version of its ports.
 
-These types of registries are more suited to be a testing ground for your ports or to provide an alternative for registries in version control systems that are
-not Git. Since no tooling is offered to manipulate the version database files,
-this method is not recommended for large collections of ports.
+These types of registries are more suited to be a testing ground for your ports or to provide an alternative for
+registries in version control systems that are not Git. Since no tooling is offered to manipulate the version database
+files, this method is not recommended for large collections of ports.
 
 See the [registries
 reference](../maintainers/registries.md#filesystem-registries) for details on
@@ -296,7 +293,7 @@ registry or disabled completely using the
 [`default-registry`](../reference/vcpkg-configuration-json.md#default-registry)
 property.
 
-**Example: Set a custom registry as default**
+#### Example: Set a custom registry as default
 
 `vcpkg-configuration.json`
 
@@ -310,7 +307,7 @@ property.
 }
 ```
 
-**Example: Disable the default registry**
+#### Example: Disable the default registry
 
 `vcpkg-configuration.json`
 
@@ -326,7 +323,7 @@ To extend the selection of ports available to install with vcpkg, you can
 specify additional registries using the [`registries`
 array](../reference/vcpkg-configuration-json.md#registries).
 
-**Example: Add custom registries to the configuration**
+#### Example: Add custom registries to the configuration
 
 > [!NOTE]
 > Depending on the registry kind, you may need to provide different information
@@ -362,7 +359,7 @@ array](../reference/vcpkg-configuration-json.md#registries).
 
 ## Recommended practices for registries
 
-**Don't rewrite version history**
+### Don't rewrite version history
 
 Once a version has been published to the versions files, do not change its
 associated `git-tree` in a git registry or directory in a filesystem registry.
@@ -374,11 +371,10 @@ changing a `git-tree` entry violates this principle.
 If the existing version has issues, prefer to create a new
 [`port-version`](../reference/vcpkg-json.md#port-version).
 
-
-**Don't delete versions files**
+### Don't delete versions files
 
 When removing a port from your registry, remove its contents from the ports
-directory and its entry in the baseline file. But _do not_ remove its associated
+directory and its entry in the baseline file. But *do not* remove its associated
 versions file.
 
 Even if a port no longer exists in the registry, as long as the versions file

--- a/vcpkg/concepts/registries.md
+++ b/vcpkg/concepts/registries.md
@@ -9,43 +9,139 @@ ms.topic: concept-article
 
 # Registries concepts
 
-Registries are collections of ports and their versions. The curated registry is
-the one hosted at <https://github.com/Microsoft/vcpkg>. vcpkg lets you create
-custom registries, which may be hosted by a variety of public or private providers.
+vcpkg hosts a selection of libraries packaged into [ports](ports.md) at
+<https://github.com/Microsoft/vcpkg>, this collection of ports is called the
+*curated registry*. However, vcpkg is not limited to just installing ports from
+the curated registry. Users are capable of extending the selection of ports by
+creating custom registries.
 
-There are currently two options to implement your own registries: a Git-based
-registry or a filesystem-based registry.
+A registry is a collection of ports and helper files arranged in a specific
+structure. By following the registry structure, ports contained in a registry
+can be installed with the same amount of features
+([versioning](../users/versioning.md), [binary
+caching](../users/binarycaching.md)) offered to ports in the curated registry.
+
+There are currently three kinds of registries: 
+
+* The [built-in registry](#built-in-registry),
+* [Git registries](#git-registries), and 
+* [filesystem registries](#filesystem-registries).
+
+vcpkg can be instructed to consider ports available in custom registries by
+using a [`vcpkg-configuration.json`
+file](../reference/vcpkg-configuration-json.md#registries). See the [Tutorial:
+Install a dependency from a Git-based registry](../consume/git-registries.md)
+article for a tutorial on how to use custom registries in your projects.
+
+## Registry structure
+
+For vcpkg to interface with a registry, it must comform with the structure
+below:
+
+* A directory named `ports`, contains the collection of ports, with each
+  subdirectory containing a specific port matching the subdirectory name. For
+  example, the files for port `foo` must be located in `ports/foo`.
+* A directory named `versions` must contain the files that comprise the [versions
+  database](#versions-database).
+
+### Versions database
+
+All registries, regardless of their kind, must contain a `versions` folder at the
+root of the registry which contains the _versions database_.
+
+There are two components to the versions database:
+
+* the baseline file, 
+* the version files.
+
+The baseline file is a JSON file named `baseline.json` located at the root of
+the `versions` directory. The purpose of the baseline file is to describe the
+set of versions that are considered to be the latest for each port in the
+registry. The layout of the baseline file depends on the kind of registry.
+
+For each port in the registry, a corresponding _version file_ must exist.
+The versions file is a JSON file with the same name as its corresponding port,
+for example, a port named `foo` must have a corresponding `foo.json` version
+file.
+
+vcpkg expects the versions files to be stored at the following location
+`versions/<prefix>/<port name>.json` inside the registry, where `<prefix>` is
+the first letter of the port name followed by a hyphen. For example, the
+version file for port `foo` must be stored in `versions/f-/foo.json`.
+
+The purpose of the version file is two-fold:
+
+* List all available versions of each port
+* Point to the retrieval locations of each of version.
+
+Same as the baseline file, the layout of the version file depends on the kind of
+registry.
+
+### Example: registry structure
+
+```
+ports/
+  foo/
+    portfile.cmake
+    vcpkg.json
+versions/
+  f-/
+    foo.json
+  baseline.json
+```
 
 ## Built-in registry
 
-The built-in registry refers to the implicit registry typically used in classic
-mode scenarios, and edited directly in the directory `VCPKG_ROOT`.
+The built-in registry is a special kind of registry. The built-in registry
+is the default registry used in some operation modes, like [classic
+mode](classic-mode.md). When a [default
+registry](../reference/vcpkg-configuration-json.md#default-registry) is not
+specified, vcpkg implicity uses the built-in registry as the default.
 
-If vcpkg was acquired using `git clone`, this will refer to the registry in `VCPKG_ROOT` itself,
-and is expected to be a clone of <https://github.com/Microsoft/vcpkg> created before running vcpkg.
+The built-in registry most often refers to the local copy of the curated
+registry created when you `git clone` the vcpkg repository from
+<https://github.com/Microsoft/vcpkg>. Some operations expect that the
+[`VCPKG_ROOT` environment variable](../users/config-environment.md#vcpkg_root)
+points to a built-in registry.
 
-Otherwise (vcpkg was acquired using the 'one liner' installer or the 'Visual Studio bundle'),
-this will be equivalent to a git registry with a `"repository"` of
-`"https://github.com/Microsoft/vcpkg"`.
+If vcpkg is acquired through the "one liner" or Visual Studio installer, the
+built-in registry becomes equivalent to a [Git registry](#git-registries)
+pointing to the <https://github.com/Microsoft/vcpkg> repository.
 
 ## Git registries
 
-Git registries are simple Git repositories. They can be shared publicly or
-privately via normal mechanisms for Git repositories. The [vcpkg
-repository](https://github.com/microsoft/vcpkg) is an example of a Git registry.
+A Git registry is a repository that follows the registry structure and leverages
+Git's capatilities to provide versioning for the ports in the registry. The
+curated registry at <https://github.com/Microsoft/vcpkg> is an implementation of
+a Git registry.
 
-Using Git registries offers the best experience for custom registries since you
-have full control over the versions and contents of your registry.
+Git registries can be hosted in any Git repository provider, allowing you to
+use your chosen Git hosting service to control access to your custom registry
+while also making your registry easy to share.
+
+Git registries are the recommended method for implementing a custom registry.
+Since the versioning mechanism is the same used by the curated registry, Git
+registries can make use of the [`x-add-version`](../commands/add-version.md) to
+manage your version database files.
+
+See the [registries reference](../maintainers/registries.md#git-registries) for
+details on how to implement a Git registry.
 
 ## Filesystem registries
 
-Filesystem registries, as the name implies, live on your filesystem. They are a
-collection of ports located in a filesystem location and offer a primitive form
-of version control using a separate path per version.
+Filesystem registries are an implementation of a registry that lives on a
+filesystem. They follow the common registry structure but don't make use of Git
+to offer versioning capabilities, instead they use a primitive form of version
+control using a distinct path for each version of its ports.
 
-These type of registries are more suited to be a testing ground for your
-packages. Or to provide an alternative for registries in version control systems
-that are not Git.
+These type of registries are more suited to be a testing ground for your ports.
+Or to provide an alternative for registries in version control systems that are
+not Git. Since no tooling is offered to manipulate the version database files,
+this method is not recommended for large collections of ports.
+
+See the [registries
+reference](../maintainers/registries.md#filesystem-registries) for details on
+how to implement a filesystem registry.
 
 ## Next steps
 

--- a/vcpkg/concepts/registries.md
+++ b/vcpkg/concepts/registries.md
@@ -11,13 +11,13 @@ ms.topic: concept-article
 ## Overview
 
 vcpkg hosts a selection of libraries packaged into [ports](ports.md) at
-<https://github.com/Microsoft/vcpkg>, this collection of ports is called the
+<https://github.com/Microsoft/vcpkg>. This collection of ports is called the
 *curated registry*. However, vcpkg is not limited to the curated registry. Users can extend the selection of ports by
 creating custom registries.
 
 A registry is a collection of ports and helper files arranged in a specific
 structure. By following the registry structure, ports contained in a registry
-can be installed with the same amount of features
+can be installed with the same features
 ([versioning](../users/versioning.md), [binary
 caching](../users/binarycaching.md)) offered to ports in the curated registry.
 
@@ -35,10 +35,9 @@ article for a tutorial on how to use custom registries in your projects.
 
 ## Registry structure
 
-For vcpkg to interface with a registry, it must comform with the structure
-below:
+For vcpkg to interface with a registry, it must conform to the following structure:
 
-* A directory named `ports`, contains the collection of ports, with each
+* A directory named `ports` contains the collection of ports, with each
   subdirectory containing a specific port matching the subdirectory name. For
   example, the files for port `foo` must be located in `ports/foo`.
 * A directory named `versions` must contain the files that comprise the [versions
@@ -59,36 +58,30 @@ versions/
 
 ## Versions database
 
-All registries, regardless of their kind, must contain a `versions` folder at the
+All registries contain a `versions` directory at the
 root of the registry which contains the _versions database_.
 
 There are two components to the versions database:
 
-* the baseline file, 
-* the version files.
+* The baseline file 
+* The version files
 
 The baseline file is a JSON file named `baseline.json` located at the root of
-the `versions` directory. The baseline file describes the
+the `versions` directory. It describes the
 set of versions that are current for each port in the
 registry. The layout of the baseline file depends on the kind of registry.
 
-For each port in the registry, a corresponding _version file_ must exist.
-The versions file is a JSON file with the same name as its corresponding port,
-for example, a port named `foo` must have a corresponding `foo.json` version
-file.
-
-vcpkg expects the versions files to be stored at the following location
-`versions/<prefix>/<port name>.json` inside the registry, where `<prefix>` is
+The versions files are JSON files with the same names as the available ports.
+They must exist at `versions/<prefix>/<port name>.json`, where `<prefix>` is
 the first letter of the port name followed by a hyphen. For example, the
-version file for port `foo` must be stored in `versions/f-/foo.json`.
+versions file for port `foo` must be at `versions/f-/foo.json`.
 
-The purpose of the version file is two-fold:
+The purpose of the versions file is two-fold:
 
 * List all available versions of each port
-* Point to the retrieval locations of each of version.
+* Point to the retrieval locations of each version.
 
-Same as the baseline file, the layout of the version file depends on the kind of
-registry.
+The format of the version file depends on the kind of the registry.
 
 ## Baseline file
 
@@ -115,24 +108,21 @@ Each baseline version entry is an object with the following properties:
   "default": {
     "foo": { "baseline": "1.0.0", "port-version": 0 },
     "bar": { "baseline": "2024-08-01", "port-version": 1 },
-    "baz": { "baseline": "vista-xp", "port-version": 0 },
+    "baz": { "baseline": "vista-xp", "port-version": 0 }
   }
 }
 ```
 
 See the reference documentation for:
 
-* baseline file layout for [Git
+* Baseline file layout for [Git
   registries](../maintainers/registries.md#git-baseline)
-* baseline file layout for [filesystem
+* Baseline file layout for [filesystem
   registries](../maintainers/registries.md#filesystem-baseline)
 
-## Version files
+## Versions files
 
-Each port in the registry has a corresponding versions file. The versions
-file is a JSON file named the same as its corresponding port, for example, a
-port named `foo` must have a corresponding `foo.json` file. 
-
+Each port in the registry has a corresponding versions file.
 Versions files are stored at `versions/<prefix>/<port name>.json` , where `<prefix>` is the first letter of
 the port name followed by a hyphen. For example, the versions file for port
 `foo` is at `versions/f-/foo.json`.
@@ -140,9 +130,9 @@ the port name followed by a hyphen. For example, the versions file for port
 The purpose of the versions file is two-fold:
 
 * List all available versions of each port
-* Point to the retrieval locations of each of these versions.
+* Point to the retrieval locations of each of these versions
 
-The layout of the version file is an object containing a `"versions"` array, with
+The layout of the versions file is an object containing a `"versions"` array, with
 each entry in that array being a version object.  A version object must contain
 the following properties: 
 
@@ -162,7 +152,7 @@ the following properties:
 * `path`: (only on filesystem registries) the value is the full path to a
   directory containing the port files for the specific version.
 
-## Example of a filesystem registry version file
+### Example of a filesystem registry version file
 
 ```json
 {
@@ -188,9 +178,9 @@ the following properties:
 
 See the reference documentation for:
 
-* version file layout for [Git
+* Versions file layout for [Git
   registries](../maintainers/registries.md#git-version-file)
-* version file layout for [filesystem
+* Versions file layout for [filesystem
   registries](../maintainers/registries.md#filesystem-version-file)
 
 ## Built-in registry
@@ -199,9 +189,9 @@ The built-in registry is a special kind of registry. The built-in registry
 is the default registry used in some operation modes, like [classic
 mode](classic-mode.md). When a [default
 registry](../reference/vcpkg-configuration-json.md#default-registry) is not
-specified, vcpkg implicity uses the built-in registry as the default.
+specified, vcpkg implicitly uses the built-in registry.
 
-The built-in registry most often refers to the local copy of the curated
+The built-in registry refers to the local copy of the curated
 registry created when you `git clone` the vcpkg repository from
 <https://github.com/Microsoft/vcpkg>. Some operations expect that the
 [`VCPKG_ROOT` environment variable](../users/config-environment.md#vcpkg_root)
@@ -214,7 +204,7 @@ pointing to the <https://github.com/Microsoft/vcpkg> repository.
 ## Git registries
 
 A Git registry is a repository that follows the registry structure and leverages
-Git's capatilities to provide versioning for the ports in the registry. The
+Git's capabilities to provide versioning for the ports in the registry. The
 curated registry at <https://github.com/Microsoft/vcpkg> is an implementation of
 a Git registry.
 
@@ -236,11 +226,8 @@ The [`x-add-version`](../commands/add-version.md) command can be used to to add
 a new port or a new version to the registry. When adding versions using this
 command there are a couple of things to keep in mind:
 
-**Remember to update the port's version**
-
 > [!IMPORTANT]
-> Always remember to update the port's version to avoid rewriting the version
-> history.
+> When adding a new version, always remember to update the port's declared version to one not already published, to avoid rewriting the version history.
 
 When you are making changes to a port, the first step should be to increase its
 version in the `vcpkg.json` file. If your changes include an update to the
@@ -268,8 +255,8 @@ The redirection options `--x-builtin-ports-root` and
 `--x-builtin-registry-versions-dir` should point to your registry's `ports` and
 `versions` directories respectively.
 
-Once, the `x-add-version` command runs succesfully, amend the last commit to
-include theversion database changes.
+Once, the `x-add-version` command runs successfully, amend the last commit to
+include the versions file changes.
 
 ```bash
 git commit --amend -m "Update foo to new version"
@@ -279,11 +266,10 @@ git commit --amend -m "Update foo to new version"
 
 Filesystem registries are an implementation of a registry that lives on a
 filesystem. They follow the common registry structure but don't make use of Git
-to offer versioning capabilities, instead they use a primitive form of version
+to offer versioning capabilities. Instead, they use a primitive form of version
 control using a distinct path for each version of its ports.
 
-These type of registries are more suited to be a testing ground for your ports.
-Or to provide an alternative for registries in version control systems that are
+These types of registries are more suited to be a testing ground for your ports or to provide an alternative for registries in version control systems that are
 not Git. Since no tooling is offered to manipulate the version database files,
 this method is not recommended for large collections of ports.
 
@@ -343,7 +329,7 @@ array](../reference/vcpkg-configuration-json.md#registries).
 **Example: Add custom registries to the configuration**
 
 > [!NOTE]
-> Depending on the registry kind you may need to provide different information
+> Depending on the registry kind, you may need to provide different information
 > in the `registries` array. See the [`vcpkg-configurtion.json`
 > reference](../reference/vcpkg-configuration-json.md#registries) to learn which
 > properties are required for each registry kind.
@@ -378,26 +364,26 @@ array](../reference/vcpkg-configuration-json.md#registries).
 
 **Don't rewrite version history**
 
-Once a version has been pubished to the version database, do not change its
+Once a version has been published to the versions files, do not change its
 associated `git-tree` in a git registry or directory in a filesystem registry.
 
 One of vcpkg's design principles is that the versions of installed dependencies
-do not change without user intervention. Rewriting the version file history by
+do not change without user intervention. Rewriting the versions file history by
 changing a `git-tree` entry violates this principle.
 
 If the existing version has issues, prefer to create a new
 [`port-version`](../reference/vcpkg-json.md#port-version).
 
 
-**Don't delete version files**
+**Don't delete versions files**
 
 When removing a port from your registry, remove its contents from the ports
 directory and its entry in the baseline file. But _do not_ remove its associated
-version file.
+versions file.
 
-Even if a port no longer exists in the registry, as long as the version file
+Even if a port no longer exists in the registry, as long as the versions file
 remains, users of the port can install old versions by using [version
-`overrides`](../users/versioning.md#overrides).s
+`overrides`](../users/versioning.md#overrides).
 
 ## Next steps
 

--- a/vcpkg/consume/boost-versions.md
+++ b/vcpkg/consume/boost-versions.md
@@ -55,7 +55,7 @@ override for your dependency as show below:
 
 When you run `vcpkg install`, you'll notice that only the version of
 `boost-optional` has been locked to `1.80.0` while the other Boost dependencies
-are using the baseline version (`1.83.0`). 
+are using the baseline version (`1.83.0`).
 
 ```console
 Fetching registry information from https://github.com/Microsoft/vcpkg (HEAD)...

--- a/vcpkg/consume/boost-versions.md
+++ b/vcpkg/consume/boost-versions.md
@@ -179,4 +179,4 @@ Here are some additional tasks to try next:
 * Install packages for custom platforms using [triplets](../users/triplets.md)
 * Lock down your versions for repeatable builds using [versioning](../users/versioning.concepts.md)
 * Reuse binaries across Continuous Integration runs using [binary caching](../users/binarycaching.md)
-* Manage your private libraries using [custom registries](../maintainers/registries.md)
+* Manage your private libraries using [custom registries](../concepts/registries.md)

--- a/vcpkg/consume/classic-mode.md
+++ b/vcpkg/consume/classic-mode.md
@@ -259,7 +259,7 @@ Here are some additional tasks to try next:
 * Install packages for custom platforms using [triplets](../users/triplets.md)
 * Lock down your versions for repeatable builds using [versioning](../users/versioning.concepts.md)
 * Reuse binaries across Continuous Integration runs using [binary caching](../users/binarycaching.md)
-* Manage your private libraries using [custom registries](../maintainers/registries.md)
+* Manage your private libraries using [custom registries](../concepts/registries.md)
 
 [Create a project]: #1---create-a-project
 [Integrate vcpkg with your build system]: #2---integrate-vcpkg-with-your-build-system

--- a/vcpkg/consume/git-registries.md
+++ b/vcpkg/consume/git-registries.md
@@ -154,4 +154,4 @@ Run the program, the output should look like this:
 
 * Lock down your versions for repeatable builds using [versioning](../users/versioning.concepts.md)
 * Reuse binaries across local or continuous integration runs using [binary caching](../users/binarycaching.md)
-* Manage your private libraries using custom [registries](../maintainers/registries.md)
+* Manage your private libraries using custom [registries](../concepts/registries.md)

--- a/vcpkg/consume/lock-package-versions.md
+++ b/vcpkg/consume/lock-package-versions.md
@@ -243,7 +243,7 @@ package versions. Read the versioning [concepts](../users/versioning.concepts.md
 Here are some additional tasks to try next:
 
 * Reuse binaries across Continuous Integration runs using [binary caching](../users/binarycaching.md)
-* Manage your private libraries using [custom registries](../maintainers/registries.md)
+* Manage your private libraries using [custom registries](../concepts/registries.md)
 
 [Create a project with a manifest]: #1---create-a-project-with-a-manifest
 [Add version constraints using a baseline]: #2---add-version-constraints-using-a-baseline

--- a/vcpkg/consume/manifest-mode.md
+++ b/vcpkg/consume/manifest-mode.md
@@ -318,7 +318,7 @@ Here are some additional tasks to try next:
 * Install packages for custom platforms, compilers, or build architectures using [triplets](../users/triplets.md)
 * Lock down your versions for repeatable builds using [versioning](../users/versioning.concepts.md)
 * Reuse binaries across local or continuous integration runs using [binary caching](../users/binarycaching.md)
-* Manage your private libraries using custom [registries](../maintainers/registries.md)
+* Manage your private libraries using custom [registries](../concepts/registries.md)
 
 [Create a project with a manifest]: #1---create-a-project-with-a-manifest
 [Integrate vcpkg with your build system]: #2---integrate-vcpkg-with-your-build-system

--- a/vcpkg/contributing/maintainer-guide.md
+++ b/vcpkg/contributing/maintainer-guide.md
@@ -32,7 +32,7 @@ form with a comment in `portfile.cmake` rather than trying to add additional por
 the curated registry's continuous integration. For example, see
 [glad@0.1.36](https://github.com/microsoft/vcpkg/blob/67cc1677c3bf5c23ea14b9d2416c7422fdeac492/ports/glad/portfile.cmake#L17).
 
-Before the introduction of [registries](../maintainers/registries.md), we accepted several
+Before the introduction of [registries](../concepts/registries.md), we accepted several
 not tested ports-as-alternatives, such as `boringssl`, that could make authoring overlay ports
 easier. This is no longer accepted because registries allow publishing of these untested ports
 without modifying the curated registry.
@@ -434,7 +434,7 @@ to update the files for all modified ports at once.
 > [!NOTE]
 > These commands require you to have committed your changes to the ports before running them. The reason is that the Git SHA of the port directory is required in these version files. But don't worry, the `x-add-version` command will warn you if you have local changes that haven't been committed.
 
-For more information, see the [Versioning reference](../users/versioning.md) and [Creating registries](../maintainers/registries.md).
+For more information, see the [Versioning reference](../users/versioning.md) and [Registries](../concepts/registries.md) articles.
 
 ## Patching
 

--- a/vcpkg/get_started/overview.md
+++ b/vcpkg/get_started/overview.md
@@ -14,7 +14,7 @@ vcpkg is a free and open-source C/C++ package manager maintained by Microsoft an
 ## Why vcpkg?
 
 - Over [2300 open-source libraries](https://github.com/microsoft/vcpkg/tree/master/ports) to choose from in a curated registry, routinely built to verify ABI compatibility
-- Create your own [custom library registry](../maintainers/registries.md) with your own custom library packages
+- Create your own [custom library registry](../concepts/registries.md) with your own custom library packages
 - Consistent, cross-platform experience for Windows, macOS, and Linux
 - Easily add libraries to your project with [any build and project system](../concepts/build-system-integration.md)
 - Build dependencies from source or download prebuilt ABI-verified binaries, with over 70 configurations available by default, and [infinite customization for your specific requirements](../concepts/triplets.md)

--- a/vcpkg/maintainers/registries.md
+++ b/vcpkg/maintainers/registries.md
@@ -90,7 +90,7 @@ versions from the repository's history.
 | [port-version](../reference/vcpkg-json.md#port-version) | integer | Port files revision |
 
 
-#### Example of a Git registry version file
+#### Example of a Git registry versions file
 
 ```json
 {
@@ -118,10 +118,10 @@ versions from the repository's history.
 
 vcpkg uses Git's capabilities to retrieve specific versions of a port contained
 in its commit history. The method used is to retrieve the `git-tree` object from
-the repository as specified in the version file of a port.
+the repository as specified in the versions file of a port.
 
 Each port directory in a Git registry has a unique SHA associated with it
-(referred as `git-tree` in the version files). The SHA is calculated using the
+(referred as `git-tree` in the versions files). The SHA is calculated using the
 contents of the directory; each time a change is commited to the repository that
 modifies a directory, its SHA is recalculated. 
 

--- a/vcpkg/maintainers/registries.md
+++ b/vcpkg/maintainers/registries.md
@@ -22,7 +22,7 @@ database](../concepts/registries.md#versions-database).
 
 ## Git registries
 
-### <a name="git-baseline"> Baseline file layout in Git registries
+### <a name="git-baseline"></a> Baseline file layout in Git registries
 
 *Top-level fields*
 

--- a/vcpkg/maintainers/registries.md
+++ b/vcpkg/maintainers/registries.md
@@ -1,281 +1,287 @@
 ---
-title: Creating registries
-description: Learn about how to create registries for vcpkg.
-ms.date: 01/10/2024
-ms.topic: tutorial
+title: Registries reference
+description: This article describes specific details on how to implement custom registries
+author: vicroms
+ms.author: viromer
+ms.date: 11/10/2024
+ms.topic: reference
 ---
-# Creating registries
-
-For information on consuming registries, see [Using registries](../consume/git-registries.md).
+# Registries reference
 
 ## Overview
 
-Registries are collections of ports and their versions. There are two major choices of implementation for registries, if you want to create your own: git registries, and filesystem registries.
+This article describes the implementation details for each kind of custom
+registry. Specifically, this file concerns with the recommended layout for each
+kind of registry and the expected contents of their respective [versions
+database](../concepts/registries.md#versions-database).
 
-Git registries are simple git repositories, and can be shared publicly or privately via normal mechanisms for git repositories. The [vcpkg repository](https://github.com/microsoft/vcpkg), for example, is a git registry.
+> [!NOTE]
+> This article contains information on how to implement custom registries. For
+> information on consuming custom registries in your project see the [Using
+> registries](../consume/git-registries.md) article. 
 
-Filesystem registries are designed as more of a testing ground. Given that they literally live on your filesystem, the only way to share them is via shared directories. However, filesystem registries can be useful as a way to represent registries held in non-git version control systems, assuming one has some way to get the registry onto the disk.
+## Git registries
 
-We expect the set of registry types to grow over time; if you would like support for registries built in your favorite public version control system, don't hesitate to open a PR.
+### <a name="git-baseline"> Baseline file layout in Git registries
 
-The basic structure of a registry is:
+*Top-level fields*
 
-- The set of versions that are considered "latest" at certain times in history, known as the "baseline".
-- The set of all the versions of all the ports, and where to find each of these in the registry.
+The top-level object in a `baseine.json` file is a dictionary, each key in this
+dictionary is a _named baseline_. Due to implementation details of Git
+registries, it is required that a _named baseline_ with the name "default"
+exists and that it contains a mapping of all the ports in the registry to their
+baseline version.
 
-### Git registries
+| Name           | Type           | Description |
+| -------------- | -------------- | ----------- |
+| `default`      | BaselineObject | The default baseline, required for Git registries. |
+| Named baseline | BaselineObject | Additional baselines. The field name corresponds to the baseline name. |
 
-As you're following along with this documentation, it may be helpful to have
-a working example to refer to. We've written one and put it here:
+*BaselineObject*
 
-[Microsoft/vcpkg-docs: vcpkg registry](https://github.com/microsoft/vcpkg-docs/tree/vcpkg-registry).
+The baseline object is a dictionary, with each key corresponding to a port name
+in the registry and its value being the latest version of the port.
 
-All git registries must have a `versions/baseline.json` file. This file contains the set of "latest versions" at a certain commit. It is laid out as a top-level object containing only the `"default"` field. This field should contain an object mapping port names to the version which is currently the latest.
+| Name      | Type                  | Description |
+| --------- | --------------------- | ----------- |
+| Port name | BaselineVersionObject | A mapping of a port name to its latest version |
 
-Here's an example of a valid baseline.json:
+*BaselineVersionObject*
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `baseline` | string | A string corresponding to the latest available version of the port in the registry. |
+| `port-version` | integer | An integer corresponding to the latest port version of the port in the registry |
+
+#### Example of a `baseline.json` file in a Git registry
+
+In a registry containing a single port named `foo` at version `1.0.0#1`, the
+`baseline.json` file contents should be:
 
 ```json
 {
   "default": {
-    "kitten": {
-      "baseline": "2.6.2",
-      "port-version": 0
-    },
-    "port-b": {
-      "baseline": "19.00",
-      "port-version": 2
+    "foo": { 
+      "baseline": "1.0.0", 
+      "port-version": "1"
     }
   }
 }
 ```
 
-The `versions` directory contains all the information about which versions of which packages are contained in the registry, along with where those versions are stored. The rest of the registry just acts as a backing store, as far as vcpkg is concerned: only things inside the `versions` directory will be used to direct how your registry is seen by vcpkg.
+### <a name="git-version-file"></a> Version file layout in Git registries
 
-Each port in a registry should exist in the versions directory as `<first letter of port>-/<name of port>.json`; in other words, the information about the `kitten` port would be located in `versions/k-/kitten.json`. This should be a top-level object with only a single field: `"versions"`. This field should contain an array of version objects:
+The `versions` directory contains all the information about which versions of
+packages are contained in the registry, along with the method to retrieve those
+versions from the repository's history.
 
-- The version of the port in question; should be exactly the same as the `vcpkg.json` file, including the version fields and `"port-version"`.
-- The `"git-tree"` field, which is a git tree; in other words, what you get when you write `git rev-parse COMMIT-ID:path/to/port`.
+*Top-level fields*
 
-The version field for ports with deprecated `CONTROL` files is `"version-string"`.
+| Name       | Type            | Description |
+| ---------- | --------------- | --------------------------- |
+| `versions` | VersionObject[] | An array of version objects. Contains an entry for each version of the port in the history of the registry. |
 
-> [!WARNING]
-> One very important part of registries is that versions should _never_ be changed. Updating to a later ref should never remove or change an existing version. It must always be safe to update a registry.
+*VersionObject*
 
-Here's an example of a valid version database for a `kitten` port with one version:
+| Name       | Type   | Description |
+| `git-tree` | string | A Git calculated SHA used to retrieve the port version |
+| [`version`<br>`version-semver`<br>`version-date`<br>`version-string`](#version) | string | Upstream version information |
+| [port-version](#port-version) | integer | Port files revision |
 
-```json
-{
-  "versions": [
-    {
-      "version": "2.6.2",
-      "port-version": 0,
-      "git-tree": "67d60699c271b7716279fdea5a5c6543929eb90e"
-    }
-  ]
-}
-```
 
-In general, it's not important where you place port directories. However, the idiom in vcpkg is to follow what the built in vcpkg registry does: your `kitten` port should be placed in `ports/kitten`.
-
-> [!WARNING]
-> One other thing to keep in mind is that when you update a registry, all previous versions should also be accessible. Since your user will set their baseline to a commit ID, that commit ID must always exist, and be accessible from your HEAD commit, which is what is actually fetched. This means that your HEAD commit should be a child of all previous HEAD commits.
-
-### Builtin registries
-
-Builtin registries are treated as special [Git registries](#git-registries). Instead of fetching from a remote url, builtin registries consult the `$VCPKG_ROOT/.git` directory of the vcpkg clone. They use the currently checked out `$VCPKG_ROOT/versions` directory as the source for versioning information.
-
-#### Adding a new version
-
-There is some git trickery involved in creating a new version of a port. The first thing to do is make some changes, update the `"port-version"` and regular version field as you need to, and then test with `overlay-ports`:
-
-  `vcpkg install kitten --overlay-ports=ports/kitten`.
-
-Once you've finished your testing, you'll need to make sure that the directory as it is is under git's purview. You'll do this by creating a temporary commit:
-
-```powershell
-> git add ports/kitten
-> git commit -m 'temporary commit'
-```
-
-Then, get the git tree ID of the directory:
-
-```powershell
-> git rev-parse HEAD:ports/kitten
-73ad3c823ef701c37421b450a34271d6beaf7b07
-```
-
-Then, you can add this version to the versions database. At the top of your `versions/k-/kitten.json`, you can add (assuming you're adding version `2.6.3#0`):
+#### Example of a Git registry version file
 
 ```json
 {
   "versions": [
     {
-      "version": "2.6.3",
-      "port-version": 0,
-      "git-tree": "73ad3c823ef701c37421b450a34271d6beaf7b07"
-    },
-    {
-      "version": "2.6.2",
-      "port-version": 0,
-      "git-tree": "67d60699c271b7716279fdea5a5c6543929eb90e"
-    }
-  ]
-}
-```
-
-Then, you'll want to modify your `versions/baseline.json` with your new version as well:
-
-```json
-{
-  "default": {
-    "kitten": {
-      "baseline": "2.6.3",
+      "git-tree": "963060040c3ca463d17136e39c7317efb15eb6a5",
+      "version": "1.2.0",
       "port-version": 0
     },
-    "port-b": {
-      "baseline": "19.00",
-      "port-version": 2
+    {
+      "git-tree": "548c90710d59c174aa9ab10a24deb69f1d75ff8f",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
+      "git-tree": "67d60699c271b7716279fdea5a5c6543929eb90e",
+      "version": "1.0.0",
+      "port-version": 0
     }
-  }
+  ]
 }
+``` 
+
+#### <a name="obtain-git-tree-sha"></a> Obtaining a `git-tree` SHA
+
+vcpkg uses Git's capabilities to retrieve specific versions of a port contained
+in its commit history. The method used is to retrieve the `git-tree` object from
+the repository as specified in the version file of a port.
+
+Each port directory in a Git registry has a unique SHA associated with it
+(referred as `git-tree` in the version files). The SHA is calculated using the
+contents of the directory; each time a change is commited to the repository that
+modifies a directory, its SHA is recalculated. 
+
+Git allows you to retrieve the contents of a given directory at any point in its
+history, provided that you know their specific SHA. By making use of this
+feature, vcpkg can index specific port versions with their respective SHA
+(`git-tree`).
+
+To obtain the SHA of a port directory at any given revision the following Git
+command can be used:
+
+```Console
+git -C <path/to/ports> ls-tree --format='%(objectname)' <commit sha> -- <portname>
+``` 
+
+Example:
+
+```Console
+git -C %VCPKG_ROOT%/ports ls-tree --format='%(objectname)' HEAD -- curl
+6ef1763f3cbe570d6378632c9b5793479c37fb07
 ```
 
-and amend your current commit:
+The command returns the SHA of the directory containing the `curl` port at the
+current revision (`HEAD`).
 
-```powershell
-> git commit --amend
+It is possible to show the contents of the `git-tree` using the command `git show <git-tree>`:
+
+```Console
+git show 6ef1763f3cbe570d6378632c9b5793479c37fb07
+tree 6ef1763f3cbe570d6378632c9b5793479c37fb07
+
+0005_remove_imp_suffix.patch
+0020-fix-pc-file.patch
+0022-deduplicate-libs.patch
+cmake-config.patch
+cmake-project-include.cmake
+dependencies.patch
+export-components.patch
+portfile.cmake
+redact-input-vars.diff
+usage
+vcpkg-cmake-wrapper.cmake
+vcpkg.json
 ```
 
-then share away!
+Or the contents of a specific file with `git show <git-tree>:<file>`:
+
+```Console
+git show 6ef1763f3cbe570d6378632c9b5793479c37fb07:usage
+curl is compatible with built-in CMake targets:
+
+    find_package(CURL REQUIRED)
+    target_link_libraries(main PRIVATE CURL::libcurl)
+```
+
+Mantaining the database files up to date using these Git commands in a manual
+process can be a difficult task. For that reason we recommend using the
+[`x-add-version` command](../commands/add-version.md), which automates the
+process as long as the repository follows the recommended [registry
+structure](../concepts/registries.md#registry-structure). See the [Tutorial:
+Publish packages to a private vcpkg registry using
+Git](../produce/publish-to-a-git-registry.md) article for an example of how to
+publish a port in a Git registry.
 
 ### Filesystem registries
 
-As you're following along with this documentation, it may be helpful to have a working example to refer to. We've written one and put it here:
+### <a name="filesystem-baseline"></a> Baseline file layout in filesystem registries
 
-[Example filesystem registry](https://github.com/vcpkg/example-filesystem-registry).
+*Top-level fields*
 
-All filesystem registries must have a `versions/baseline.json` file. This file contains the set of "latest versions" for a certain version of the registry. It is laid out as a top-level object containing a map from version name to "baseline objects", which map port names to the version which is considered "latest" for that version of the registry.
+The top-level object in a `baseine.json` file is a dictionary, each key in this
+dictionary is a _named baseline_. Baselines should contain mappings of all the
+ports in the registry to their baseline version.
 
-Filesystem registries need to decide on a versioning scheme. Unlike git registries, which have the implicit versioning scheme of refs, filesystem registries can't rely on the version control system here. One possible option is to do a daily release, and have your "versions" be dates.
+| Name           | Type           | Description |
+| -------------- | -------------- | ----------- |
+| Named baseline | BaselineObject | Additional baselines. The field name corresponds to the baseline name. |
 
-> [!WARNING]
-> A baseline must not be modified once published. If you want to change or update versions, you need to create a new baseline in the `baseline.json` file.
+*BaselineObject*
 
-Here's an example of a valid `baseline.json`, for a registry that has decided upon dates for their versions:
+The baseline object is a dictionary, with each key corresponding to a port name
+in the registry and its value being the latest version of the port.
+
+| Name      | Type                  | Description |
+| --------- | --------------------- | ----------- |
+| Port name | BaselineVersionObject | A mapping of a port name to its latest version |
+
+*BaselineVersionObject*
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `baseline` | string | A string corresponding to the latest available version of the port in the registry. |
+| `port-version` | integer | An integer corresponding to the latest port version of the port in the registry |
+
+The layout of the baseline file in a filesystem registry is the same as for [Git
+registries](#git-baseline-layout). The only difference being that filesystems
+don't require a `default` baseline.
+
+#### Example of a `baseline.json` file in a Git registry
 
 ```json
 {
-  "2021-04-16": {
-    "kitten": {
-      "baseline": "2.6.2",
-      "port-version": 0
-    },
-    "port-b": {
-      "baseline": "19.00",
-      "port-version": 2
-    }
-  },
-  "2021-04-15": {
-    "kitten": {
-      "baseline": "2.6.2",
-      "port-version": 0
-    },
-    "port-b": {
-      "baseline": "19.00",
+  "my-baseline": {
+    "foo": {
+      "baseline": "1.0.0",
       "port-version": 1
     }
   }
 }
 ```
+### <a name="filesystem-version-file"></a> Version file layout in Git registries
 
-The `versions` directory contains all the information about which versions of which packages are contained in the registry, along with where those versions are stored. The rest of the registry just acts as a backing store, as far as vcpkg is concerned: only things inside the `versions` directory will be used to direct how your registry is seen by vcpkg.
+The `versions` directory contains all the information about which versions of
+packages are contained in the registry, along with the method to retrieve those
+versions from a filesystem location.
 
-Each port in a registry should exist in the versions directory as `<first letter of port>-/<name of port>.json`; in other words, the information about the `kitten` port would be located in `versions/k-/kitten.json`. This should be a top-level object with only a single field: `"versions"`. This field should contain an array of version objects:
+*Top-level fields*
 
-- The version of the port in question; should be exactly the same as the `vcpkg.json` file, including the version fields and `"port-version"`.
-- The `"path"` field: a relative directory, rooted at the base of the registry (in other words, the directory where `versions` is located), to the port directory. It should look something like `"$/path/to/port/dir`"
+| Name       | Type            | Description |
+| ---------- | --------------- | --------------------------- |
+| `versions` | VersionObject[] | An array of version objects. Contains an entry for each version of the port in the registry. |
 
-The version field for ports with deprecated `CONTROL` files is `"version-string"`.
+*VersionObject*
 
-In general, it's not important where you place port directories. However, the idiom in vcpkg is to follow somewhat closely to what the built in vcpkg registry does: your `kitten` port at version `x.y.z` should be placed in `ports/kitten/x.y.z`, with port versions appended as you see fit (although since `#` is not a good character to use for file names, perhaps use `_`).
+| Name       | Type   | Description |
+| `path`     | string | The filesystem location where the port files for the corresponding version are located |
+| [`version`<br>`version-semver`<br>`version-date`<br>`version-string`](#version) | string | Upstream version information |
+| [port-version](#port-version) | integer | Port files revision |
 
-> [!WARNING]
-> One very important part of registries is that versions should _never_ be changed. One should never remove or change an existing version. Your changes to your registry shouldn't change behavior to downstream users.
+When specifying the `path` of a registry, the `$` character can be used to
+reference the root of the registry. Otherwise, absolute paths can be used
+instead.
 
-Here's an example of a valid version database for a `kitten` port with one version:
-
-```json
-{
-  "versions": [
-    {
-      "version": "2.6.2",
-      "port-version": 0,
-      "path": "$/ports/kitten/2.6.2_0"
-    }
-  ]
-}
-```
-
-#### Add a new version
-
-Unlike git registries, adding a new version to a filesystem registry mostly involves a lot of copying. The first thing to do is to copy the latest version of your port into a new version directory, update the version and `"port-version"` fields as you need to, and then test with `overlay-ports`:
-
-  `vcpkg install kitten --overlay-ports=ports/kitten/new-version`.
-
-Once you've finished your testing, you can add this new version to the top of your `versions/k-/kitten.json`:
+#### Example of a filesystem registry version file
 
 ```json
 {
   "versions": [
     {
-      "version": "2.6.3",
-      "port-version": 0,
-      "path": "$/ports/kitten/2.6.3_0"
+      "git-tree": "$/ports/foo/1.2.0",
+      "version": "1.2.0",
+      "port-version": 0
     },
     {
-      "version": "2.6.2",
-      "port-version": 0,
-      "path": "$/ports/kitten/2.6.2_0"
+      "git-tree": "$/ports/foo/1.1.0",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
+      "git-tree": "$/ports/foo/1.0.0",
+      "version": "1.0.0",
+      "port-version": 0
     }
   ]
 }
 ```
 
-Then, you'll want to modify your `versions/baseline.json` with your new version as well (remember not to modify existing baselines):
+## Next steps
 
-```json
-{
-  "2021-04-17": {
-    "kitten": {
-      "baseline": "2.6.3",
-      "port-version": 0
-    },
-    "port-b": {
-      "baseline": "19.00",
-      "port-version": 2
-    }
-  },
-  "2021-04-16": {
-    "kitten": {
-      "baseline": "2.6.2",
-      "port-version": 0
-    },
-    "port-b": {
-      "baseline": "19.00",
-      "port-version": 2
-    }
-  },
-  "2021-04-15": {
-    "kitten": {
-      "baseline": "2.6.2",
-      "port-version": 0
-    },
-    "port-b": {
-      "baseline": "19.00",
-      "port-version": 1
-    }
-  }
-}
-```
+Here are some tasks to try next:
 
-And you're done!
+* [Read the registries conceptual documentation](../concepts/registries.md)
+* [Create your own Git-based registry](../produce/publish-to-a-git-registry.md)
+* [Install packages from a custom registry](../consume/git-registries.md)

--- a/vcpkg/maintainers/registries.md
+++ b/vcpkg/maintainers/registries.md
@@ -24,7 +24,7 @@ database](../concepts/registries.md#versions-database).
 
 ### <a name="git-baseline"></a> Baseline file layout in Git registries
 
-*Top-level fields*
+#### Top-level fields
 
 The top-level object in a `baseine.json` file is a dictionary, each key in this
 dictionary is a _named baseline_. Due to implementation details of Git
@@ -37,7 +37,7 @@ baseline version.
 | `default`      | BaselineObject | The default baseline, required for Git registries. |
 | Named baseline | BaselineObject | Additional baselines. The field name corresponds to the baseline name. |
 
-*BaselineObject*
+#### BaselineObject
 
 The baseline object is a dictionary, with each key corresponding to a port name
 in the registry and its value being the latest version of the port.
@@ -46,7 +46,7 @@ in the registry and its value being the latest version of the port.
 | --------- | --------------------- | ----------- |
 | Port name | BaselineVersionObject | A mapping of a port name to its latest version |
 
-*BaselineVersionObject*
+#### BaselineVersionObject
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
@@ -75,20 +75,19 @@ The `versions` directory contains all the information about which versions of
 packages are contained in the registry, along with the method to retrieve those
 versions from the repository's history.
 
-*Top-level fields*
+#### Top-level fields
 
 | Name       | Type            | Description |
 | ---------- | --------------- | --------------------------- |
 | `versions` | VersionObject[] | An array of version objects. Contains an entry for each version of the port in the history of the registry. |
 
-*VersionObject*
+#### VersionObject
 
 | Name       | Type   | Description |
 | ---------- | ------ | ----------- |
 | `git-tree` | string | A git tree SHA used to retrieve the port contents |
 | [`version`<br>`version-semver`<br>`version-date`<br>`version-string`](../reference/vcpkg-json.md#version) | string | Upstream version information |
 | [port-version](../reference/vcpkg-json.md#port-version) | integer | Port files revision |
-
 
 #### Example of a Git registry versions file
 
@@ -135,7 +134,7 @@ command can be used:
 
 ```Console
 git -C <path/to/ports> ls-tree --format='%(objectname)' <commit sha> -- <portname>
-``` 
+```
 
 Example:
 
@@ -190,7 +189,7 @@ publish a port in a Git registry.
 
 ### <a name="filesystem-baseline"></a> Baseline file layout in filesystem registries
 
-*Top-level fields*
+#### Top-level fields
 
 The top-level object in a `baseine.json` file is a dictionary, each key in this
 dictionary is a _named baseline_. Baselines should contain mappings of all the
@@ -200,7 +199,7 @@ ports in the registry to their baseline version.
 | -------------- | -------------- | ----------- |
 | Named baseline | BaselineObject | Additional baselines. The field name corresponds to the baseline name. |
 
-*BaselineObject*
+#### BaselineObject
 
 The baseline object is a dictionary, with each key corresponding to a port name
 in the registry and its value being the latest version of the port.
@@ -209,7 +208,7 @@ in the registry and its value being the latest version of the port.
 | --------- | --------------------- | ----------- |
 | Port name | BaselineVersionObject | A mapping of a port name to its latest version |
 
-*BaselineVersionObject*
+#### BaselineVersionObject
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
@@ -224,7 +223,7 @@ don't require a `default` baseline.
 
 ```json
 {
-  "my-baseline": {
+  "2024-12-01": {
     "foo": {
       "baseline": "1.0.0",
       "port-version": 1
@@ -232,6 +231,7 @@ don't require a `default` baseline.
   }
 }
 ```
+
 ### <a name="filesystem-version-file"></a> Version file layout in Git registries
 
 The `versions` directory contains all the information about which versions of
@@ -262,17 +262,17 @@ instead.
 {
   "versions": [
     {
-      "git-tree": "$/ports/foo/1.2.0",
+      "path": "$/ports/foo/1.2.0",
       "version": "1.2.0",
       "port-version": 0
     },
     {
-      "git-tree": "$/ports/foo/1.1.0",
+      "path": "$/ports/foo/1.1.0",
       "version": "1.1.0",
       "port-version": 0
     },
     {
-      "git-tree": "$/ports/foo/1.0.0",
+      "path": "$/ports/foo/1.0.0",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/vcpkg/maintainers/registries.md
+++ b/vcpkg/maintainers/registries.md
@@ -84,6 +84,7 @@ versions from the repository's history.
 *VersionObject*
 
 | Name       | Type   | Description |
+| ---------- | ------ | ----------- |
 | `git-tree` | string | A Git calculated SHA used to retrieve the port version |
 | [`version`<br>`version-semver`<br>`version-date`<br>`version-string`](#version) | string | Upstream version information |
 | [port-version](#port-version) | integer | Port files revision |
@@ -246,6 +247,7 @@ versions from a filesystem location.
 *VersionObject*
 
 | Name       | Type   | Description |
+| ---------- | ------ | ----------- |
 | `path`     | string | The filesystem location where the port files for the corresponding version are located |
 | [`version`<br>`version-semver`<br>`version-date`<br>`version-string`](#version) | string | Upstream version information |
 | [port-version](#port-version) | integer | Port files revision |

--- a/vcpkg/maintainers/registries.md
+++ b/vcpkg/maintainers/registries.md
@@ -86,8 +86,8 @@ versions from the repository's history.
 | Name       | Type   | Description |
 | ---------- | ------ | ----------- |
 | `git-tree` | string | A Git calculated SHA used to retrieve the port version |
-| [`version`<br>`version-semver`<br>`version-date`<br>`version-string`](#version) | string | Upstream version information |
-| [port-version](#port-version) | integer | Port files revision |
+| [`version`<br>`version-semver`<br>`version-date`<br>`version-string`](../reference/vcpkg-json.md#version) | string | Upstream version information |
+| [port-version](../reference/vcpkg-json.md#port-version) | integer | Port files revision |
 
 
 #### Example of a Git registry version file
@@ -217,7 +217,7 @@ in the registry and its value being the latest version of the port.
 | `port-version` | integer | An integer corresponding to the latest port version of the port in the registry |
 
 The layout of the baseline file in a filesystem registry is the same as for [Git
-registries](#git-baseline-layout). The only difference being that filesystems
+registries](#git-baseline). The only difference being that filesystems
 don't require a `default` baseline.
 
 #### Example of a `baseline.json` file in a Git registry
@@ -249,8 +249,8 @@ versions from a filesystem location.
 | Name       | Type   | Description |
 | ---------- | ------ | ----------- |
 | `path`     | string | The filesystem location where the port files for the corresponding version are located |
-| [`version`<br>`version-semver`<br>`version-date`<br>`version-string`](#version) | string | Upstream version information |
-| [port-version](#port-version) | integer | Port files revision |
+| [`version`<br>`version-semver`<br>`version-date`<br>`version-string`](../reference/vcpkg-json.md#version) | string | Upstream version information |
+| [port-version](../reference/vcpkg-json.md#port-version) | integer | Port files revision |
 
 When specifying the `path` of a registry, the `$` character can be used to
 reference the root of the registry. Otherwise, absolute paths can be used

--- a/vcpkg/maintainers/registries.md
+++ b/vcpkg/maintainers/registries.md
@@ -63,7 +63,7 @@ In a registry containing a single port named `foo` at version `1.0.0#1`, the
   "default": {
     "foo": { 
       "baseline": "1.0.0", 
-      "port-version": "1"
+      "port-version": 1
     }
   }
 }
@@ -85,7 +85,7 @@ versions from the repository's history.
 
 | Name       | Type   | Description |
 | ---------- | ------ | ----------- |
-| `git-tree` | string | A Git calculated SHA used to retrieve the port version |
+| `git-tree` | string | A git tree SHA used to retrieve the port contents |
 | [`version`<br>`version-semver`<br>`version-date`<br>`version-string`](../reference/vcpkg-json.md#version) | string | Upstream version information |
 | [port-version](../reference/vcpkg-json.md#port-version) | integer | Port files revision |
 

--- a/vcpkg/reference/vcpkg-configuration-json.md
+++ b/vcpkg/reference/vcpkg-configuration-json.md
@@ -170,6 +170,6 @@ Package patterns may contain only lowercase letters, digits, and `-`, with an op
 
 See the [Using Registries documentation](../concepts/package-name-resolution.md) for more information on how port names are resolved.
 
-[Git Registry]: ../maintainers/registries.md#git-registries
-[Filesystem Registry]: ../maintainers/registries.md#filesystem-registries
-[Builtin Registry]: ../maintainers/registries.md#builtin-registries
+[Git Registry]: ../concepts/registries.md#git-registries
+[Filesystem Registry]: ../concepts/registries.md#filesystem-registries
+[Builtin Registry]: ../concepts/registries.md#built-in-registry

--- a/vcpkg/users/authentication.md
+++ b/vcpkg/users/authentication.md
@@ -6,7 +6,7 @@ ms.topic: concept-article
 ---
 # Remote authentication
 
-[Registries](registries.md) and [`vcpkg_from_git()`](../maintainers/functions/vcpkg_from_git.md) directly use the Git command line tools to fetch remote resources. Some of these resources may be protected from anonymous access and need authentication or credentials.
+[Registries](../concepts/registries.md) and [`vcpkg_from_git()`](../maintainers/functions/vcpkg_from_git.md) directly use the Git command line tools to fetch remote resources. Some of these resources may be protected from anonymous access and need authentication or credentials.
 
 The strategies below all seek to achieve the same fundamental goal: `git clone https://....` should succeed without interaction. This enables vcpkg to be separated from the specifics of your authentication scheme, ensuring forward compatibility with any additional security improvements in the future.
 

--- a/vcpkg/users/config-environment.md
+++ b/vcpkg/users/config-environment.md
@@ -45,7 +45,7 @@ This environment variable can be set to a triplet name which will be used for un
 
 ## VCPKG_OVERLAY_PORTS
 
-This environment variable adds additional [overlay ports or overlay port directories](registries.md#overlays) considered after those listed on the command line. Multiple values are separated with the platform dependent PATH separator (Windows `;` | others `:`)
+This environment variable adds additional [overlay ports or overlay port directories](../concepts/overlay-ports.md) considered after those listed on the command line. Multiple values are separated with the platform dependent PATH separator (Windows `;` | others `:`)
 
 
 Example (Windows): `C:\custom-ports\boost;C:\custom-ports\sqlite3;C:\other-ports`

--- a/vcpkg/users/examples/versioning.getting-started.md
+++ b/vcpkg/users/examples/versioning.getting-started.md
@@ -255,7 +255,7 @@ The last thing to discuss is how overlay ports interact with versioning resoluti
 
 Going into more detail, when you provide an overlay for a port, vcpkg will always use the overlay port without caring what version is contained in it. The reasons are two-fold: (1) it is consistent with the existing behavior of overlay ports of completely masking the existing port, and (2) overlay ports do not (and are not expected to) provide enough information to power vcpkg's versioning feature.
 
-If you want to have flexible port customization along with versioning, you should consider [making your own custom registry](../../maintainers/registries.md).
+If you want to have flexible port customization along with versioning, you should consider [making your own custom registry](../../concepts/registries.md).
 
 ## Further reading
 

--- a/vcpkg/users/versioning-troubleshooting.md
+++ b/vcpkg/users/versioning-troubleshooting.md
@@ -14,7 +14,7 @@ This guide is intended for users experiencing issues with [versioning](./version
 ## <a name="inspect-versions-file"></a> Inspecting the version file for a port
 
 > [!NOTE]
-> The process described below is meant to work for ports from the [vcpkg registry](<https://github.com/Microsoft/vcpkg>). See our [registry](../maintainers/registries.md#git-registries) documentation to learn how the versioning database is implemented in custom registries.
+> The process described below is meant to work for ports from the [vcpkg registry](<https://github.com/Microsoft/vcpkg>). See our [registry](../concepts/registries.md) documentation to learn how the versioning database is implemented in custom registries.
 
 To inspect the versions database of a specific port:  
 1. Navigate to the `vcpkg/versions` directory.


### PR DESCRIPTION
This PR contains major changes to the registry's documentation:

* Adds new sections to the [registries concept article (preview)](https://review.learn.microsoft.com/en-us/vcpkg/concepts/registries?branch=pr-en-us-429)
  * Registry directory structure
  * Versions database
  * Built-in registry
  * Obtain `git-tree` SHA
  * Best practices for registries
* Changes the registries [reference article (preview)](https://review.learn.microsoft.com/en-us/vcpkg/maintainers/registries?branch=pr-en-us-429)
  * Remove conceptual sections
  * Add JSON schema documentation for baseline.json and version files
* Fix broken links generated by these changes  