### PR TITLE
Multiple fixes

### DIFF
--- a/vcpkg/concepts/glossary.md
+++ b/vcpkg/concepts/glossary.md
@@ -98,11 +98,21 @@ Patches are used to fix bugs, add features, or customize the behavior of a packa
 
 A vcpkg-specific term, a port contains:
 
-* Metadata about a package: name, version, dependencies, supported features,
+* Metadata about a [package](#package): name, version, dependencies, supported features,
   etc.
 * Instructions to acquire, build if necessary, and install the package.
 
 See the [ports documentation](../concepts/ports.md) to learn more.
+
+## R
+
+### Registry
+
+A vcpkg-specific term, a registry is a collection of [ports](#port) available to install in vcpkg.  Registries follow a specific
+structure described in the [registries documentation](../concepts/registries.md).
+
+vcpkg offers a curated registry available at <https://github.com/Microsoft/vcpkg>, and users can create their own [custom
+registries](../produce/publish-to-a-git-registry.md) to host their own collection of ports.
 
 ## S
 

--- a/vcpkg/examples/snippets/get-started/CMakeUserPresets.json
+++ b/vcpkg/examples/snippets/get-started/CMakeUserPresets.json
@@ -1,13 +1,13 @@
 {
-    "version": 2,
-    "configurePresets": [
-      {
-        "name": "default",
-        "inherits": "vcpkg",
-        "environment": {
-          "VCPKG_ROOT": "<path to vcpkg>"
-        }
+  "version": 2,
+  "configurePresets": [
+    {
+      "name": "default",
+      "inherits": "vcpkg",
+      "environment": {
+        "VCPKG_ROOT": "<path to vcpkg>"
       }
-    ]
-  }
-  
+    }
+  ]
+}
+ 

--- a/vcpkg/reference/binarycaching.md
+++ b/vcpkg/reference/binarycaching.md
@@ -413,6 +413,7 @@ The ABI Hash considers:
 - The ABI Hash of each dependency
 - All helper functions referenced by `portfile.cmake` (heuristic)
 - The version of CMake used
+- The version of PowerShell used (Windows)
 - The contents of any environment variables listed in
   [`VCPKG_ENV_PASSTHROUGH`](../users/triplets.md#vcpkg_env_passthrough)
 - The toolchain file's textual contents

--- a/vcpkg/users/buildsystems/snippets/cmake-integration/CMakePresets.json
+++ b/vcpkg/users/buildsystems/snippets/cmake-integration/CMakePresets.json
@@ -1,6 +1,5 @@
 {
   "version": 2,
-
   "configurePresets": [
     {
       "name": "debug",

--- a/vcpkg/users/buildsystems/snippets/cmake-integration/CMakeUserPresets.json
+++ b/vcpkg/users/buildsystems/snippets/cmake-integration/CMakeUserPresets.json
@@ -1,11 +1,11 @@
 {
   "version": 2,
-
   "configurePresets": [
     {
-      "name": "debug",
-      "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      "name": "default",
+      "inherits": "debug",
+      "environment": {
+        "VCPKG_ROOT": "<path to vcpkg>"
       }
     }
   ]

--- a/vcpkg/users/host-dependencies.md
+++ b/vcpkg/users/host-dependencies.md
@@ -1,7 +1,9 @@
 ---
 title: Host dependencies
 description: Describes host dependencies, tools packaged by vcpkg for use by ports or custom build systems.
-ms.date: 01/10/2024
+author: vicroms
+ms.author: viromer
+ms.date: 01/31/2025
 ms.topic: concept-article
 ---
 # Host dependencies
@@ -87,5 +89,5 @@ Only tools installed in the [`tools` folder](../reference/installation-tree-layo
 for the host triplet are added to `CMAKE_PROGRAM_PATH`.
 Effectively, the following locations are added:
 
-* `${VCPKG_INSTALLED/DIR}/${VCPKG_HOST_TRIPLET}/tools`
-* `${VCPKG_INSTALLED/DIR}/${VCPKG_HOST_TRIPLET}/tools/*/bin`
+* `${VCPKG_INSTALLED_DIR}/${VCPKG_HOST_TRIPLET}/tools`
+* `${VCPKG_INSTALLED_DIR}/${VCPKG_HOST_TRIPLET}/tools/*/bin`


### PR DESCRIPTION
Fixes: #440 #437 #435 #431

- Fix errors in examples of `VCPKG_USE_HOST_TOOLS` and `CMakeUserPresets.json`
- Add definition for "Registry" in the glossary
- Add entry for PowerShell version in the ABI hash keys
