### PR TITLE
Revise usage and copyright instructions

### DIFF
--- a/vcpkg/get_started/get-started-packaging.md
+++ b/vcpkg/get_started/get-started-packaging.md
@@ -163,7 +163,6 @@ vcpkg_from_github(
     HEAD_REF cmake-sample-lib
 )
 
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
@@ -174,8 +173,8 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME "my_sample_lib")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 ```
 
 This `portfile` defines how to download, build, install, and package a specific
@@ -200,10 +199,10 @@ C++ library from GitHub using vcpkg.
   package configuration files to be compatible with vcpkg.
 - `file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")`: Deletes the
   include directory from the debug installation to prevent overlap.
-- `file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION ...)`: Installs the LICENSE
-  file to the package's share directory and renames it to copyright.
-- `configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" ...)`: Copies a usage
+- `file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" ...)`: Copies a usage
   instruction file to the package's share directory.
+- `vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")`: Installs the LICENSE
+  file to the package's share directory and renames it to copyright.
 
 For more information, refer to the [maintainer guide](../contributing/maintainer-guide.md).
 
@@ -249,6 +248,7 @@ Building vcpkg-sample-library:x64-windows...
 -- Configuring x64-windows
 -- Building x64-windows-dbg
 -- Building x64-windows-rel
+-- Installing: C:/Users/dev/demo/vcpkg/packages/vcpkg-sample-library_x64-windows/share/vcpkg-sample-library/usage
 -- Installing: C:/Users/dev/demo/vcpkg/packages/vcpkg-sample-library_x64-windows/share/vcpkg-sample-library/copyright
 -- Performing post-build validation
 Stored binaries in 1 destinations in 94 ms.

--- a/vcpkg/maintainers/handling-usage-files.md
+++ b/vcpkg/maintainers/handling-usage-files.md
@@ -17,13 +17,13 @@ name>/usage`) that describes the minimal steps necessary to integrate with a bui
 ### Supplying a usage file
 
 To provide usage documentation create a text file named `usage` in the port's `share`
-installation directory. The recommended method is to call the `configure_file()` function in
+installation directory. The recommended method is to call the `file(INSTALL ...)` function in
 `portfile.cmake`.
 
 For example:
 
 ```cmake
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 ```
 
 After installing ports, vcpkg detects files installed to `${CURRENT_PACKAGES_DIR}/share/${PORT}/usage` and prints their usage instructions.
@@ -45,7 +45,7 @@ Packages with CMake targets:
 ```text
 <port> provides CMake targets:
 
-    <instructions>
+  <instructions>
 ```
 
 Header-only libraries:
@@ -53,7 +53,7 @@ Header-only libraries:
 ```text
 <port> is header-only and can be used from CMake via:
 
-    <instructions>
+  <instructions>
 ```
 
 #### Example of `usage` file
@@ -61,6 +61,6 @@ Header-only libraries:
 ```text
 proj provides CMake targets:
 
-    find_package(PROJ CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE PROJ::proj)
+  find_package(PROJ CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE PROJ::proj)
 ```


### PR DESCRIPTION
Adopt `vcpkg_install_copyright()`.
Adopt `file(INSTALL ...)` for usage. (Nothing to configure, and no project-mode dependency.)
Adopt indent of 2 spaces for usage (as hardcoded in vcpkg tool usage heuristics).