### PR TITLE
Add warning regarding github vcpkg binary cache removal

### DIFF
--- a/vcpkg/consume/binary-caching-github-actions-cache.md
+++ b/vcpkg/consume/binary-caching-github-actions-cache.md
@@ -9,6 +9,10 @@ ms.date: 01/10/2024
 ---
 # Tutorial: Set up a vcpkg binary cache using GitHub Actions Cache
 
+> [!WARNING]
+> Vcpkg binary cache for GitHub Actions is **deprecated** and this tutorial is **no longer maintained**.  
+> For more information and migration guidance, please see [GitHub PR #1662](https://github.com/microsoft/vcpkg-tool/pull/1662).
+
 [!INCLUDE [experimental](../../includes/experimental.md)]
 
 vcpkg supports using the GitHub Actions cache as binary caching storage when running in the context of

--- a/vcpkg/consume/binary-caching-github-actions-cache.md
+++ b/vcpkg/consume/binary-caching-github-actions-cache.md
@@ -10,7 +10,7 @@ ms.date: 01/10/2024
 # Tutorial: Set up a vcpkg binary cache using GitHub Actions Cache
 
 > [!CAUTION]
-> Vcpkg binary cache for GitHub Actions is **deprecated** and this tutorial is **no longer maintained**.  
+> The GitHub Actions Cache backend for binary caching has been removed. This tutorial is no longer maintained.  
 > For more information and migration guidance, please see [GitHub PR #1662](https://github.com/microsoft/vcpkg-tool/pull/1662).
 
 [!INCLUDE [experimental](../../includes/experimental.md)]

--- a/vcpkg/consume/binary-caching-github-actions-cache.md
+++ b/vcpkg/consume/binary-caching-github-actions-cache.md
@@ -9,7 +9,7 @@ ms.date: 01/10/2024
 ---
 # Tutorial: Set up a vcpkg binary cache using GitHub Actions Cache
 
-> [!WARNING]
+> [!CAUTION]
 > Vcpkg binary cache for GitHub Actions is **deprecated** and this tutorial is **no longer maintained**.  
 > For more information and migration guidance, please see [GitHub PR #1662](https://github.com/microsoft/vcpkg-tool/pull/1662).
 


### PR DESCRIPTION
Support for GitHub action cache as a binary caching provider has been removed https://github.com/microsoft/vcpkg-tool/pull/1662.

This PR adds warning to the documentation regarding this. 