### PR TITLE
Remove references to GitHub Actions Cache and the `x-gha` provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ _site/
 _themes*/
 _repo.*/
 .DS_Store
+.vscode
 
 .openpublishing.buildcore.ps1

--- a/includes/removed.md
+++ b/includes/removed.md
@@ -1,0 +1,3 @@
+> [!CAUTION]
+> This section covers a feature that has been removed from vcpkg in the latest version.
+> The documentation for this feature is no longer maintained.

--- a/includes/removed.md
+++ b/includes/removed.md
@@ -1,3 +1,3 @@
 > [!CAUTION]
-> This section covers a feature that has been removed from vcpkg in the latest version.
+> This section covers a feature that has been removed from vcpkg.
 > The documentation for this feature is no longer maintained.

--- a/vcpkg/TOC.yml
+++ b/vcpkg/TOC.yml
@@ -65,8 +65,6 @@
       href: consume/binary-caching-local.md
     - name: Set up a binary cache using a NuGet feed
       href: consume/binary-caching-nuget.md
-    - name: Set up a binary cache using GitHub Actions cache
-      href: consume/binary-caching-github-actions-cache.md
     - name: Set up a binary cache using GitHub Packages in your GitHub Actions workflow
       href: consume/binary-caching-github-packages.md
   - name: Improve reliability by caching dependency assets

--- a/vcpkg/concepts/continuous-integration.md
+++ b/vcpkg/concepts/continuous-integration.md
@@ -69,8 +69,6 @@ project's dependencies on each CI run.
 To learn more about binary caching read these articles:
 
 * [What is binary Caching](../consume/binary-caching-overview.md)
-* [Binary caching in GitHub
-  Actions](../consume/binary-caching-github-actions-cache.md)
 * [Authenticate NuGet
   feeds](../consume/binary-caching-nuget.md#provide-authentication-credentials)
 * [Binary caching configuration reference](../reference/binarycaching.md)

--- a/vcpkg/consume/binary-caching-default.md
+++ b/vcpkg/consume/binary-caching-default.md
@@ -79,4 +79,3 @@ Here are other tasks to try next:
 * [Set up a local binary cache](binary-caching-local.md)
 * [Set up a binary cache using a NuGet feed](binary-caching-nuget.md)
 * [Set up a binary cache in your GitHub Actions workflow using GitHub Packages](binary-caching-github-packages.md)
-* [Set up a binary cache in your GitHub Actions workflow using GitHub Actions Cache](binary-caching-github-actions-cache.md)

--- a/vcpkg/consume/binary-caching-github-actions-cache.md
+++ b/vcpkg/consume/binary-caching-github-actions-cache.md
@@ -4,14 +4,15 @@ description: This tutorial shows how to set up a vcpkg binary cache using a NuGe
 author: vicroms
 ms.author: viromer
 ms.topic: tutorial
-ms.date: 01/10/2024
+ms.date: 05/01/2025
 #CustomerIntent: As a vcpkg user, I want to setup binary caching in my GitHub Actions workflow using GitHub Packages as the binary cache storage
+ROBOTS: NOINDEX
 ---
 # Tutorial: Set up a vcpkg binary cache using GitHub Actions Cache
 
 > [!CAUTION]
 > The GitHub Actions Cache backend for binary caching has been removed. This tutorial is no longer maintained.  
-> For more information and migration guidance, please see [GitHub PR #1662](https://github.com/microsoft/vcpkg-tool/pull/1662).
+> For more information and migration guidance, please see [GitHub Pull Request #1662](<https://github.com/microsoft/vcpkg-tool/pull/1662>).
 
 [!INCLUDE [experimental](../../includes/experimental.md)]
 

--- a/vcpkg/consume/binary-caching-github-packages.md
+++ b/vcpkg/consume/binary-caching-github-packages.md
@@ -4,7 +4,7 @@ description: This tutorial shows how to set up a vcpkg binary cache using a NuGe
 author: vicroms
 ms.author: viromer
 ms.topic: tutorial
-ms.date: 01/10/2024
+ms.date: 5/1/2025
 #CustomerIntent: As a vcpkg user, I want to setup binary caching in my GitHub Actions workflow using GitHub Packages as the binary cache storage
 zone_pivot_group_filename: zone-pivot-groups.json
 zone_pivot_groups: os-runner

--- a/vcpkg/consume/binary-caching-github-packages.md
+++ b/vcpkg/consume/binary-caching-github-packages.md
@@ -163,4 +163,3 @@ Here are other tasks to try next:
 * [Change the default binary cache location](binary-caching-default.md)
 * [Set up a local binary cache](binary-caching-local.md)
 * [Set up a binary cache using a NuGet feed](binary-caching-nuget.md)
-* [Set up a binary cache in your GitHub Actions workflow using GitHub Actions Cache](binary-caching-github-actions-cache.md)

--- a/vcpkg/consume/binary-caching-local.md
+++ b/vcpkg/consume/binary-caching-local.md
@@ -116,4 +116,3 @@ Here are other tasks to try next:
 * [Change the default binary cache location](binary-caching-default.md)
 * [Set up a binary cache using a NuGet feed](binary-caching-nuget.md)
 * [Set up a binary cache in your GitHub Actions workflow using GitHub Packages](binary-caching-github-packages.md)
-* [Set up a binary cache in your GitHub Actions workflow using GitHub Actions Cache](binary-caching-github-actions-cache.md)

--- a/vcpkg/consume/binary-caching-nuget.md
+++ b/vcpkg/consume/binary-caching-nuget.md
@@ -287,5 +287,3 @@ Here are other tasks to try next:
 * [Change the default binary cache location](binary-caching-default.md)
 * [Set up a local binary cache](binary-caching-local.md)
 * [Set up a binary cache in your GitHub Actions workflow using GitHub Packages](binary-caching-github-packages.md)
-* [Set up a binary cache in your GitHub Actions workflow using GitHub Actions
-  Cache](binary-caching-github-actions-cache.md)

--- a/vcpkg/consume/binary-caching-overview.md
+++ b/vcpkg/consume/binary-caching-overview.md
@@ -49,5 +49,4 @@ Here are other tasks to try next:
 * [Set up a local binary cache](binary-caching-local.md)
 * [Set up a binary cache using a NuGet feed](binary-caching-nuget.md)
 * [Set up a binary cache in your GitHub Actions workflow using GitHub Packages](binary-caching-github-packages.md)
-* [Set up a binary cache in your GitHub Actions workflow using GitHub Actions Cache](binary-caching-github-actions-cache.md)
 * [Authenticate to private NuGet feeds](../reference/binarycaching.md#nuget-credentials)

--- a/vcpkg/consume/third-party-authentication.nuget.md
+++ b/vcpkg/consume/third-party-authentication.nuget.md
@@ -165,4 +165,3 @@ Here are other tasks to try next:
 - [Change the default binary cache location](binary-caching-default.md)
 - [Set up a local binary cache](binary-caching-local.md)
 - [Set up a binary cache in your GitHub Actions workflow using GitHub Packages]binary-caching-github-packages.md)
-- [Set up a binary cache in your GitHub Actions workflow using GitHub Actions Cache](binary-caching-github-actions-cache.md)

--- a/vcpkg/github-integration.md
+++ b/vcpkg/github-integration.md
@@ -11,17 +11,14 @@ ms.topic: concept-article
 
 ## <a name="caching"></a> Caching vcpkg-built binaries for your GitHub Actions workflows
 
-vcpkg's binary caching feature reduces the amount of time it takes to build projects that use GitHub Actions for continuous integration. There are two binary cache providers that are available to GitHub repositories, the GitHub Actions cache provider and the GitHub Packages NuGet cache provider. For more information on these GitHub features, see [GitHub Actions cache](https://docs.github.com/actions/using-workflows/caching-dependencies-to-speed-up-workflows) and [GitHub Packages](https://docs.github.com/packages/learn-github-packages/introduction-to-github-packages). For more information on vcpkg binary caching, see our [binary caching feature documentation](./users/binarycaching.md).
-
-### <a name="caching-actions"></a> The GitHub Actions cache provider
-
-[!INCLUDE [experimental](../includes/experimental.md)]
-
-The GitHub Actions cache is intended to store a repository's intermediate build files that don't change often between jobs or workflow runs. For GitHub users, the GitHub Actions cache is a natural fit for vcpkg's binary caching, and it is easier to configure than vcpkg's GitHub Package binary caching integration. GitHub provides a few different tools to manage your Actions caches, which include REST APIs and an extension to the `gh` command line tool, so that you can optimize caches for your workflow. vcpkg's integration with GitHub Actions cache is through the `x-gha` binary source provider.
+vcpkg's binary caching feature reduces the amount of time it takes to build projects that use GitHub Actions for continuous
+integration. For more information, read the [binary caching feature documentation](./users/binarycaching.md).
 
 ### <a name="caching-nuget"></a> The GitHub Packages NuGet cache provider
 
-GitHub Packages make it possible for a repository to publish binary artifacts for public or private use. Beyond hosting storage for published packages, GitHub Packages supports a variety of package management tools by acting as a package registry. vcpkg can use the NuGet registry interface to GitHub Packages as a cache for vcpkg binary artifacts, by using the `nuget` binary source provider. This integration with GitHub Packages is not as straightforward as the GitHub Actions cache integration and management of the cached binaries is more difficult, making the GitHub Actions cache a better option for most users.
+[GitHub Packages](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages) let repositories
+publish binary artifacts for public or private use. Beyond hosting storage for published packages, GitHub Packages support
+offers a NuGet registry interface that vcpkg can use as a binary cache, with the [`nuget` binary source provider](../consume/binary-caching-github-packages.md).
 
 ## <a name="dependency-graph"></a> The GitHub dependency graph
 

--- a/vcpkg/github-integration.md
+++ b/vcpkg/github-integration.md
@@ -18,7 +18,7 @@ integration. For more information, read the [binary caching feature documentatio
 
 [GitHub Packages](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages) let repositories
 publish binary artifacts for public or private use. Beyond hosting storage for published packages, GitHub Packages support
-offers a NuGet registry interface that vcpkg can use as a binary cache, with the [`nuget` binary source provider](../consume/binary-caching-github-packages.md).
+offers a NuGet registry interface that vcpkg can use as a binary cache, with the [`nuget` binary source provider](./consume/binary-caching-github-packages.md).
 
 ## <a name="dependency-graph"></a> The GitHub dependency graph
 

--- a/vcpkg/produce/test-registry-ports-gha.md
+++ b/vcpkg/produce/test-registry-ports-gha.md
@@ -3,7 +3,7 @@ title: Test your custom registry ports using vcpkg with GitHub Actions
 description: This tutorial shows users how to set up continuous integration environment for their registry's vcpkg ports using GitHub Actions.
 author: vicroms
 ms.author: viromer
-ms.date: 1/10/2024
+ms.date: 5/1/2025
 ms.topic: how-to
 
 #customer intent: As an advanced vcpkg user, I want to add continuous integration to test the vcpkg ports in my custom Git registry
@@ -12,18 +12,16 @@ ms.topic: how-to
 # Test your custom registry ports using vcpkg with GitHub Actions
 
 Once you have set up a custom registry of vcpkg ports, you may want to add
-Continous Integration to validate that all your dependencies can be built
+Continuos Integration (CI) to validate that all your dependencies can be built
 successfully.
 
-The main vcpkg registry at
-[Microsoft/vcpkg](<https://github.com/Microsoft/vcpkg>) is tested by the vcpkg
-team using continuous integration (CI) with Azure DevOps. This ensures that
-adding new packages or updating existing ones does not break consumers.
+The main vcpkg registry at [Microsoft/vcpkg](<https://github.com/Microsoft/vcpkg>) is tested by the vcpkg team using Azure
+DevOps Pipelines. This ensures that adding new packages or updating existing ones does not break consumers.
 
 In this article, we show you how to set up a CI environment to test the vcpkg
 ports in your own registry.
 
-In this article, you'll learn to:
+In this article, you'll learn to set up a CI workflow for your registry running in GitHub Actions:
 
 > [!divclass]
 >
@@ -33,15 +31,13 @@ In this article, you'll learn to:
 ## Prerequisites
 
 * A GitHub account
-* Your own [vcpkg Git registry](../produce/publish-to-a-git-registry.md)
-* Completion of the [binary
-  caching](../consume/binary-caching-github-actions-cache.md)
-  and [asset caching](../consume/asset-caching.md) tutorials.
-* Knowledge about GitHub Actions workflows
+* A [vcpkg Git registry](../produce/publish-to-a-git-registry.md)
+* Read the [binary caching](../consume/binary-caching-github-packages.md) tutorial
+* Read the [asset caching](../consume/asset-caching.md) tutorial
 
 ## Set up a binary cache and asset cache for your GitHub Actions workflows
 
-Building a large collection of ports is an expensive task both in terms of
+Testing a large collection of ports is an expensive task both in terms of
 time and computing power. We strongly recommend that before engaging CI for
 your ports, you invest in setting up a binary cache and an asset cache for your
 GitHub Action workflows.
@@ -53,30 +49,25 @@ artifacts in subsequent runs. It can also help mitigate issues where the
 upstream repository is unreliable: for example, a broken download URL.
 
 For detailed instructions on how to set up these caches read our [binary
-caching](../consume/binary-caching-github-actions-cache.md) and [asset
+caching](../consume/binary-caching-github-packages.md) and [asset
 caching](../consume/asset-caching.md) articles.
 
 ## Example: Enable asset and binary caching in a GitHub Actions workflow
 
 ```yml
-steps:
-  - name: Enable GitHub Actions Cache backend
-    uses: actions/github-script@v7
-    with:
-      script: |
-        core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-        core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+env:
+  FEED_URL: https://nuget.pkg.github.com/<OWNER>/index.json
 
-  - name: some vcpkg task
+steps:
+  - name: Install vcpkg ports
     run: "${{ github.workspace }}/vcpkg/vcpkg install"
     env: 
       X_VCPKG_ASSET_SOURCES: "clear;x-azurl,https://my.domain.com/container,{{ secrets.SAS }},readwrite"
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/<OWNER>/index.json,readwrite"
 ```
 
-This example shows how to set up a binary cache and asset cache in a
-GitHub Actions workflow. You should adapt this snippet to use on your
-own workflow's YAML file.
+This example shows how to set up a binary cache and asset cache in a GitHub Actions workflow. You should adapt this snippet 
+to use on your own workflow's YAML file.
 
 Breaking down this snippet:
 
@@ -285,8 +276,6 @@ left out of the tests.
 The following articles may be useful to you when setting up a CI environment.
 
 * [Authenticate to private Git registries](../consume/gha-authentication.md)
-* [Set up a binary cache using GHA
-  Cache](../consume/binary-caching-github-actions-cache.md)
 * [Set up an asset cache](../consume/asset-caching.md)
 * [Binary cache reference](../users/binarycaching.md)
 * [Asset cache reference](../users/assetcaching.md)

--- a/vcpkg/reference/binarycaching.md
+++ b/vcpkg/reference/binarycaching.md
@@ -138,10 +138,6 @@ Commas (`,`) are valid as part of a object prefix in GCS. Remember to escape the
 
 [!INCLUDE [removed](../../includes/removed.md)]
 
-```
-x-gha[,<rw>]
-```
-
 ### <a name="azuniversal"></a> Universal Packages in Azure Artifacts
 
 [!INCLUDE [experimental](../../includes/experimental.md)]

--- a/vcpkg/reference/binarycaching.md
+++ b/vcpkg/reference/binarycaching.md
@@ -24,7 +24,7 @@ Binary caching is configured with the environment variable `VCPKG_BINARY_SOURCES
 | [`x-aws,<prefix>[,<rw>]`](#aws)                  | **Experimental: will change or be removed without warning**<br>Adds an AWS S3 source.                                            |
 | [`x-aws-config,<parameter>`](#aws)               | **Experimental: will change or be removed without warning**<br>Configure all AWS S3 providers.                                   |
 | [`x-cos,<prefix>[,<rw>]`](#cos)                  | **Experimental: will change or be removed without warning**<br>Adds a Tencent Cloud Object Storage source.                       |
-| [`x-gha,<rw>]`](#gha)                            | **Experimental: will change or be removed without warning**<br>Use the GitHub Actions cache as source.                           |
+| [`x-gha,<rw>]`](#gha)                            | **Removed: This feature has been removed from vcpkg** |
 | [`x-az-universal,<organization>,<project>,<feed>[,<rw>]`](#azuniversal)                   | **Experimental: will change or be removed without warning**<br>Use Universal Packages in Azure Artifacts as source.             |
 | `interactive`                                    | Enables interactive credential management for [NuGet](#nuget) (for debugging; requires `--debug` on the command line)            |
 
@@ -136,33 +136,10 @@ Commas (`,`) are valid as part of a object prefix in GCS. Remember to escape the
 
 ### <a name="gha"></a> GitHub Actions cache
 
-[!INCLUDE [experimental](../../includes/experimental.md)]
+[!INCLUDE [removed](../../includes/removed.md)]
 
 ```
 x-gha[,<rw>]
-```
-
-Adds the GitHub Actions cache as a provider. This binary caching provider is only valid in the context of a GitHub Actions workflow. This provider requires both of the `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` environment variables to be set. Setting these environment variables correctly is covered in the following Quickstart section.
-
-#### <a name="gha-quickstart"></a> Quickstart
-
-In order for vcpkg to make use of the GitHub Actions Cache, it needs the Actions Cache URL and Runtime Token. To do this, both values should be exported as environment variables in a workflow step similar to the following:
-
-```yaml
-- uses: actions/github-script@v7
-  with:
-    script: |
-      core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-      core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-```
-
-Specifying these values as environment variables instead of vcpkg command line arguments is by design as the GitHub Actions Cache binary caching provider can only be used from a GitHub Actions workflow.
-
-Once the environment variables have been exported, vcpkg can be run with the GitHub Actions binary caching provider like this:
-
-```yaml
-- name: Install dependencies via vcpkg
-  run: vcpkg install zlib --binarysource="clear;x-gha,readwrite"
 ```
 
 ### <a name="azuniversal"></a> Universal Packages in Azure Artifacts
@@ -194,7 +171,6 @@ x-az-universal,organization_url,,feed_name,readwrite
 ```
 
 Leave the `project_name` parameter empty to make vcpkg download and publish Universal Packages to your feed at an organization scope.
-
 
 ### <a name="http"></a> HTTP provider
 
@@ -228,14 +204,19 @@ http,https://cache.example.com/{name}/{version}/{sha},readwrite,Authorization: B
 ### <a name="nuget"></a> NuGet provider
 
 Add a NuGet server with the `-Source` NuGet CLI parameter:
+
 ```
 nuget,<uri>[,<rw>]
 ```
+
 Use a NuGet config file with the `-Config` NuGet CLI parameter:
+
 ```
 nugetconfig,<path>[,<rw>]
 ```
+
 Configure the timeout for NuGet sources:
+
 ```
 nugettimeout,<seconds>
 ```
@@ -401,7 +382,7 @@ Use a Personal Access Token (PAT) as the password for maximum security. You can 
 > [!NOTE]
 > Information on the ABI Hash is provided as an implementation note and will change without notice.
 
-For every build, vcpkg calculates an _ABI Hash_ to determine equivalence. If two builds have the same ABI Hash, vcpkg will consider them identical and reuse the binaries across projects and machines.
+For every build, vcpkg calculates an *ABI Hash* to determine equivalence. If two builds have the same ABI Hash, vcpkg will consider them identical and reuse the binaries across projects and machines.
 
 The ABI Hash considers:
 
@@ -429,7 +410,7 @@ The calculated ABI Hashes are stored in each package and in the current installe
 ### Example ABI Hash of zlib
 
 Enable [debug output](../users/binarycaching-troubleshooting.md#debug-output) to
-print the full Application Binary Interface (ABI) hash of a pacakge. For zlib: 
+print the full Application Binary Interface (ABI) hash of a pacakge. For zlib:
 
 ```
 [DEBUG] Trying to hash <path>\buildtrees\zlib\x86-windows.vcpkg_abi_info.txt

--- a/vcpkg/users/binarycaching.md
+++ b/vcpkg/users/binarycaching.md
@@ -89,7 +89,5 @@ syntax reference](../reference/binarycaching.md):
 
 * [Set up a local binary cache](../consume/binary-caching-local.md)
 * [Set up a binary cache using a NuGet feed](../consume/binary-caching-nuget.md)
-* [Set up a binary cache with GitHub Actions
-  cache](../consume/binary-caching-github-actions-cache.md)
 * [Set up a binary cache with GitHub
   Packages](../consume/binary-caching-github-packages.md)

--- a/vcpkg/users/config-environment.md
+++ b/vcpkg/users/config-environment.md
@@ -124,11 +124,3 @@ This environment variable sets the language vcpkg uses to display messages. It s
 
 For example: 1033 corresponds to the English (US) language.
 For a full list of supported LCIDs see [Localization](https://github.com/microsoft/vcpkg-tool/blob/main/docs/localization.md).
-
-## ACTIONS_CACHE_URL
-
-This environment variable is the URL to the GitHub Actions cache. See [Binary Caching](../reference/binarycaching.md#gha) for more details.
-
-## ACTIONS_RUNTIME_TOKEN
-
-This environment variable is the access token to the GitHub Actions cache. See [Binary Caching](../reference/binarycaching.md#gha) for more details.


### PR DESCRIPTION
- [X] Deindex GitHub Actions Cache tutorial
- [X] Remove links to GitHub Actions Cache tutorial
- [X] Add removal notice on reference page

Updating the "Test your custom registry using vcpkg with GitHub Actions" requires a large rewrite, a follow-up PR containing those changes will be created. 