### PR TITLE
Use git diff --output to avoid PowerShell destroying the diff.

### DIFF
--- a/vcpkg/consume/install-locally-modified-package.md
+++ b/vcpkg/consume/install-locally-modified-package.md
@@ -154,7 +154,7 @@ endif()
 In the source code directory, run the following command to generate a patch file.
 
 ```Console
-git diff > "$OVERLAY_LOCATION/vcpkg-sample-library/add-dynamic-lib-support.patch"
+git diff --output "$OVERLAY_LOCATION/vcpkg-sample-library/add-dynamic-lib-support.patch"
 ```
 
 This creates a file named `add-dynamic-lib-support.patch` in your overlay port,

--- a/vcpkg/examples/patching.md
+++ b/vcpkg/examples/patching.md
@@ -148,7 +148,7 @@ Now we can modify `pngpriv.h` to use `abort()` everywhere.
 The output of `git diff` is already in patch format, so we just need to save the patch into the `ports/libpng` directory.
 
 ```powershell
-PS buildtrees\libpng\src\v1.6.37-c993153cdf> git diff --ignore-space-at-eol | out-file -enc ascii ..\..\..\..\ports\libpng\use-abort-on-all-platforms.patch
+PS buildtrees\libpng\src\v1.6.37-c993153cdf> git diff --output ..\..\..\..\ports\libpng\use-abort-on-all-platforms.patch
 ```
 
 Finally, we need to apply the patch after extracting the source.


### PR DESCRIPTION
PowerShell tries to do encoding and newline conversions; if we use --output then git always does the right thing itself.