### PR TITLE
fix: add readwrite option when nuget.config is used

### DIFF
--- a/vcpkg/consume/binary-caching-nuget.md
+++ b/vcpkg/consume/binary-caching-nuget.md
@@ -270,7 +270,7 @@ export VCPKG_BINARY_SOURCES="clear;nuget,<feed url>,readwrite"
 If you're using a `nuget.config` file, instead do:
 
 ```bash
-export VCPKG_BINARY_SOURCES="clear;nugetconfig,<path to nuget.config>"
+export VCPKG_BINARY_SOURCES="clear;nugetconfig,<path to nuget.config>,readwrite"
 ```
 
 ::: zone-end


### PR DESCRIPTION
Without the option, vcpkg doesn't push cache to the nuget source and doesn't provide any message about it