### PR TITLE
Fix snippets/cmake-integration/CMakePresets.json

### DIFF
--- a/vcpkg/users/buildsystems/snippets/cmake-integration/CMakePresets.json
+++ b/vcpkg/users/buildsystems/snippets/cmake-integration/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "configurePresets": [
     {
       "name": "debug",
@@ -9,3 +9,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
CMakePresets.json manifests before version 3 (CMake < 3.21) must have both the `generator` and `binaryDir` entries. Otherwise, loading the preset fails.

Link: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#configure-preset