### PR TITLE
Note that all files are hashed by `x-add-version`

### DIFF
--- a/vcpkg/commands/add-version.md
+++ b/vcpkg/commands/add-version.md
@@ -27,6 +27,9 @@ To use the command:
 
 This will add or update the version entry for your port in the version database.
 
+> [!NOTE]
+> The hash used in the version database is computed from the complete file contents of the port. Any untracked files in the port directory will affect the resulting hash. Users should ensure that any files they do not intend to track are removed before invoking this command.
+
 ## Options
 
 All vcpkg commands support a set of [common options](common-options.md).


### PR DESCRIPTION
Note that the `x-add-version` command uses all of the files in a port directory when computing that port's version hash.

The `x-add-version` command computes a port's version hash based on all files in a port directory regardless of whether those files are tracked by git.  Prior to https://github.com/microsoft/vcpkg-tool/pull/1616, only files tracked by git were used when computing the hash.  Add a note that explains this change.

Pursuant to discussion in https://github.com/microsoft/vcpkg/pull/48165.