### PR TITLE
Clarify GITHUB_TOKEN limitations for GitHub package caching (#536)

### DIFF
--- a/vcpkg/consume/binary-caching-github-packages.md
+++ b/vcpkg/consume/binary-caching-github-packages.md
@@ -185,6 +185,20 @@ jobs:
 
 ::: zone-end
 
+> [!NOTE]
+> The default `GITHUB_TOKEN` provided by GitHub Actions does **not** have the required permissions to upload or download cached packages.  
+> To enable package caching to GitHub Packages, use a **Personal Access Token (PAT)** instead and ensure it includes the following scopes:
+>
+> - `packages:read`
+> - `packages:write`
+>
+> Store the PAT as a repository secret (for example, `VCPKG_PAT_TOKEN`) and reference it in your workflow:
+>
+> ```yaml
+> -Password: "${{ secrets.VCPKG_PAT_TOKEN }}"
+> -Source: "${{ env.FEED_URL }}"
+> ```
+
 And that's it! vcpkg will now upload or restore packages from your NuGet feed hosted on GitHub
 Packages inside your GitHub Actions workflow.
 


### PR DESCRIPTION
Summary

This pull request updates the [binary-caching-github-packages.md](https://github.com/MicrosoftDocs/vcpkg-docs/blob/main/vcpkg/consume/binary-caching-github-packages.md)
 page to clarify that the default GITHUB_TOKEN provided by GitHub Actions does not have sufficient permissions for uploading or downloading cached packages when using GitHub Packages with vcpkg.

Fixes

Fixes issue [#536](https://github.com/MicrosoftDocs/vcpkg-docs/issues/536)
“GITHUB_TOKEN package caching doesn't work”.

Problem

The documentation currently suggests using GITHUB_TOKEN for authentication during vcpkg package caching in GitHub Actions.
However, caching fails because the default GitHub Actions token lacks the required permissions (packages:read and packages:write) to access GitHub Packages.

What’s Changed

Added a clarifying note explaining that the default GITHUB_TOKEN cannot be used for caching.

Recommended using a Personal Access Token (PAT) with packages:read and packages:write scopes.

Provided an example snippet showing how to reference a stored PAT secret in the workflow file.

Added Markdown Block
> [!NOTE]
> The default `GITHUB_TOKEN` provided by GitHub Actions does **not** have the required permissions to upload or download cached packages.  
> To enable package caching to GitHub Packages, use a **Personal Access Token (PAT)** instead and ensure it includes the following scopes:
>
> - `packages:read`
> - `packages:write`
>
> Store the PAT as a repository secret (for example, `VCPKG_PAT_TOKEN`) and reference it in your workflow:
>
> ```yaml
> -Password: "${{ secrets.VCPKG_PAT_TOKEN }}"
> -Source: "${{ env.FEED_URL }}"
> ```

Why This Fix Helps

This clarification helps users avoid confusion when setting up binary caching with GitHub Packages. It prevents failed caching attempts and improves documentation accuracy and developer experience.

