### PR TITLE
docs: fix typo "vcpkg-configuration.json" in Registries concept (fixes #542)

### DIFF
--- a/vcpkg/concepts/registries.md
+++ b/vcpkg/concepts/registries.md
@@ -323,7 +323,7 @@ array](../reference/vcpkg-configuration-json.md#registries).
 
 > [!NOTE]
 > Depending on the registry kind, you may need to provide different information
-> in the `registries` array. See the [`vcpkg-configurtion.json`
+> in the `registries` array. See the [`vcpkg-configuration.json`
 > reference](../reference/vcpkg-configuration-json.md#registries) to learn which
 > properties are required for each registry kind.
 


### PR DESCRIPTION
Hi @nyoma-diamond and @vicroms,

Summary:
Fixes a typo in the Registries concept documentation where "vcpkg-configurtion.json" was incorrectly referenced.

Fixes:
Closes #542 – Typo "vcpkg-configurtion.json" in Registries concepts article.

Problem:
In the Note block under "Example: Add custom registries to the configuration", the reference to the vcpkg-configuration.json file had a missing “a” (vcpkg-configurtion.json). This could confuse readers following the instructions.

What’s Changed:
Corrected the typo from vcpkg-configurtion.json → vcpkg-configuration.json in the Registries concept documentation.

I’ve submitted this fix and would appreciate it if the PR could be reviewed and merged. Please let me know if any further edits are needed. Thank you!

Note: This change ensures the documentation references the correct file, helping readers follow instructions accurately and avoiding confusion or errors.

