### PR TITLE
Updated for October 2025 xbox triplets work

### DIFF
--- a/vcpkg/users/platforms/xbox.md
+++ b/vcpkg/users/platforms/xbox.md
@@ -9,11 +9,11 @@ ms.topic: concept-article
 # Xbox
 
 > [!NOTE]
-> Xbox is not tested as part of vcpkg repository's continuous integration process, so regressions can occur as part of library updates. 
+> Xbox is not tested as part of vcpkg repository's continuous integration process, so regressions can occur as part of library updates.
 
 ## Xbox community triplets
 
-vcpkg includes [community triplets](https://github.com/microsoft/vcpkg/tree/master/triplets/community) for [Microsoft GDK](https://aka.ms/gdk) PC and [Xbox](https://aka.ms/gdkx) development. They make use of the MSVC compiler toolset (Visual Studio 2019 version 16.11 or later).
+vcpkg includes [community triplets](https://github.com/microsoft/vcpkg/tree/master/triplets/community) for Xbox development using the [Microsoft GDK with Xbox Extensions](https://aka.ms/gdkx). They make use of the MSVC compiler toolset (Visual Studio 2019 version 16.11 or later).
 
 There are two variants for each triplet: static and dynamic linking.
 
@@ -26,15 +26,23 @@ There are two variants for each triplet: static and dynamic linking.
 
 The ``static`` linking triplets are set to use the MSVC Runtime as a DLL (i.e. ``VCPKG_CRT_LINKAGE dynamic``) as that's the recommended and supported usage scenario.
 
+> [!NOTE]
+> For [Microsoft GDK](https://aka.ms/gdk) development targeting Windows Desktop and Handheld devices, use the existing `x64-windows`, `x64-windows-static-md`, `arm64-windows`, and `arm64-windows-static-md` triplets with the [ms-gdk](https://github.com/microsoft/vcpkg/tree/master/ports/ms-gdk) port.
+
 ## Building with the Windows SDK
 
-The Windows SDK (19041) or later includes the system headers required to build against the ``WINAPI_FAMILY_GAMES`` API partition used by the Xbox Game OS. Therefore, most libraries can be built against these triplets without having access to the NDA *Microsoft GDK with Xbox Extensions*.
+The Windows SDK (22000) or later includes the system headers required to build against the ``WINAPI_FAMILY_GAMES`` API partition used by the Xbox Game OS. Therefore, most libraries can be built against these triplets without having access to the NDA *Microsoft GDK with Xbox Extensions*.
 
 ## Building with the Microsoft GDK with Xbox Extensions
 
 Libraries that make use of DirectX graphics APIs must be built using a custom variant of Direct3D 12.X used by the Xbox Game OS, and this requires access to the NDA *Microsoft GDK with Xbox Extensions*. Note that the Xbox Game OS does not support Direct3D 11, Direct2D/DirectWrite, OpenGL, GDI, or any older version of Direct3D.
 
-Libraries that require these headers must use the **`ms-gdkx`** "stub" port to indicate this requirement. This port looks for paths pointed to by ``GameDKLatest``, ``GameGXDKLatest``, and ``GameGRDKLatest`` environment variables.
+Libraries that require these headers must use the [ms-gdkx](https://github.com/microsoft/vcpkg/tree/master/ports/ms-gdkx) "stub" port to indicate this requirement. This port looks for paths pointed to using environment variables.
+
+| Microsot GDK          | Environment Variables                        |
+|-----------------------|----------------------------------------------|
+| October 2025 or later | GameDKCoreLatest, GameDKXboxLatest           |
+| April 2025 or earlier | GameDKLatest, GameGXDKLatest, GameGRDKLatest |
 
 > [!NOTE]
 > Xbox game developers are responsible for ensuring that they and their publishers have appropriate and correct licensing terms for use of any 3rd party software components per the terms of their Title License Agreement. Be sure to seek appropriate legal advice for any use of open-source components in your title.


### PR DESCRIPTION
For the October 2025 GDK, there is a 'new layout' and associated environment variables. Support for this is included in the November 2025 release of VCPKG and the VCPKG tool.

This also includes mention of the **ms-gdk** port which is related.