### PR TITLE
Miscellaneous fixes

### DIFF
--- a/vcpkg/consume/manifest-mode.md
+++ b/vcpkg/consume/manifest-mode.md
@@ -26,7 +26,8 @@ Manifest mode is also required to use advanced features like
 In this tutorial, you will learn how to:
 
 > [!div class="checklist"]
-> * [Create a project with a manifest]
+> * [Create a C++ project]
+> * [Create a vcpkg manifest](#create-manifest)
 > * [Integrate vcpkg with your build system]
 > * [Install dependencies]
 > * [Build the project]
@@ -39,25 +40,32 @@ In this tutorial, you will learn how to:
 * A C++ compiler
 * (Optional) CMake or MSBuild
 
-## 1 - Create a project with a manifest
+## 1 - Create a C++ project
 
 In a new folder, create a source file named `main.cxx` with these contents:
 
+`main.cxx`
+
 :::code language="cpp" source="../examples/snippets/manifest-mode-cmake/main.cxx":::
 
-The code references the open-source libraries: `cxxopts`, `fmt`, and `range-v3`; which are all
-available in the vcpkg public registry at <https://github.com/Microsoft/vcpkg>.
+The example code references the open-source libraries: `cxxopts`, `fmt`, and 
+`range-v3`; which are all available in the vcpkg public registry at 
+<https://github.com/Microsoft/vcpkg>.
 
-To declare these dependencies, create a file named `vcpkg.json` in the same directory as your project:
+## <a name="create-manifest"></a>2 - Create the project's manifest (`vcpkg.json`)
 
-`vcpkg.json`:
+To declare these dependencies, create a file named `vcpkg.json` in the same 
+directory as your project.
+
+`vcpkg.json`
 
 :::code language="json" source="../examples/snippets/manifest-mode-cmake/vcpkg.json":::
 
-You only need to specify your direct dependencies in the `"dependencies"` list. When it runs, vcpkg
-resolves and installs any required transitive dependencies.
+You only need to specify the project's direct dependencies in the 
+`"dependencies"` list, vcpkg resolves and installs any required transitive 
+dependencies.
 
-## 2 - Integrate vcpkg with your build system
+## 3 - Integrate vcpkg with your build system
 
 In this step we show you how to integrate vcpkg with CMake or MSBuild, so that your project dependencies get automatically installed or restored whenever you build the project.
 
@@ -104,7 +112,7 @@ CMake configure call.
 
 ---
 
-## 3 - Install dependencies
+## 4 - Install dependencies
 
 If you're using CMake or MSBuild and followed the previous step, you can skip ahead to the next step:
 [Build the project].
@@ -152,7 +160,7 @@ range-v3 provides CMake targets:
 
 When the command finishes, all built packages will be present in a `vcpkg_installed` directory. The specific location of this directory depends on your build system; usually, inside the build system's default output folder, or next to your `vcpkg.json` file. 
 
-## 4 - Build the project
+## 5 - Build the project
 
 ### [MSBuild](#tab/build-MSBuild)
 

--- a/vcpkg/consume/manifest-mode.md
+++ b/vcpkg/consume/manifest-mode.md
@@ -27,9 +27,9 @@ In this tutorial, you will learn how to:
 
 > [!div class="checklist"]
 > * [Create a C++ project]
-> * [Create a vcpkg manifest](#create-manifest)
+> * [Create a vcpkg manifest]
 > * [Integrate vcpkg with your build system]
-> * [Install dependencies]
+> * [Install dependencies with vcpkg]
 > * [Build the project]
 
 ## Prerequisites
@@ -40,7 +40,7 @@ In this tutorial, you will learn how to:
 * A C++ compiler
 * (Optional) CMake or MSBuild
 
-## 1 - Create a C++ project
+## Create a C++ project
 
 In a new folder, create a source file named `main.cxx` with these contents:
 
@@ -52,7 +52,7 @@ The example code references the open-source libraries: `cxxopts`, `fmt`, and
 `range-v3`; which are all available in the vcpkg public registry at 
 <https://github.com/Microsoft/vcpkg>.
 
-## <a name="create-manifest"></a>2 - Create the project's manifest (`vcpkg.json`)
+## Create a vcpkg manifest (`vcpkg.json`)
 
 To declare these dependencies, create a file named `vcpkg.json` in the same 
 directory as your project.
@@ -65,11 +65,11 @@ You only need to specify the project's direct dependencies in the
 `"dependencies"` list, vcpkg resolves and installs any required transitive 
 dependencies.
 
-## 3 - Integrate vcpkg with your build system
+## Integrate vcpkg with your build system
 
 In this step we show you how to integrate vcpkg with CMake or MSBuild, so that your project dependencies get automatically installed or restored whenever you build the project.
 
-If you're using a different build system, skip to the next step: [Install dependencies].
+If you're using a different build system, skip to the next step: [Install dependencies with vcpkg].
 
 ### [MSBuild](#tab/msbuild)
 
@@ -112,7 +112,7 @@ CMake configure call.
 
 ---
 
-## 4 - Install dependencies
+## Install dependencies with vcpkg
 
 If you're using CMake or MSBuild and followed the previous step, you can skip ahead to the next step:
 [Build the project].
@@ -160,7 +160,7 @@ range-v3 provides CMake targets:
 
 When the command finishes, all built packages will be present in a `vcpkg_installed` directory. The specific location of this directory depends on your build system; usually, inside the build system's default output folder, or next to your `vcpkg.json` file. 
 
-## 5 - Build the project
+## Build the project
 
 ### [MSBuild](#tab/build-MSBuild)
 
@@ -328,7 +328,8 @@ Here are some additional tasks to try next:
 * Reuse binaries across local or continuous integration runs using [binary caching](../users/binarycaching.md)
 * Manage your private libraries using custom [registries](../concepts/registries.md)
 
-[Create a project with a manifest]: #1---create-a-project-with-a-manifest
-[Integrate vcpkg with your build system]: #2---integrate-vcpkg-with-your-build-system
-[Install dependencies]: #3---install-dependencies
-[Build the project]: #4---build-the-project
+[Create a C++ project]: #create-a-c-project
+[Create a vcpkg manifest]: #create-a-vcpkg-manifest-vcpkgjson
+[Integrate vcpkg with your build system]: #integrate-vcpkg-with-your-build-system
+[Install dependencies with vcpkg]: #install-dependencies-with-vcpkg
+[Build the project]: #build-the-project

--- a/vcpkg/contributing/maintainer-guide.md
+++ b/vcpkg/contributing/maintainer-guide.md
@@ -99,6 +99,10 @@ stem (`ip`) and thus are considered to have the same name.
 An exception to this guideline is made for names that are strongly associated
 with a single project. For example: `libpng`, `openssl` and `zlib`.
 
+To avoid confusion for users, we may limit the frequency at which a port can be
+renamed once it has been added to the public registry. Our current policy is to
+not allow more than one rename per year.
+
 ### Use GitHub draft PRs
 
 GitHub Draft PRs are a great way to get CI or human feedback on work that isn't yet ready to merge.

--- a/vcpkg/contributing/maintainer-guide.md
+++ b/vcpkg/contributing/maintainer-guide.md
@@ -270,6 +270,13 @@ Examples:
 
 ### <a name="default-features-should-enable-behaviors-not-apis"></a> Default features must not add APIs
 
+> [!NOTE]
+> A feature enabled by default by the upstream build system, does not imply that
+> the feature should be added to the [`default-features`](../reference/vcpkg-json.md#dependency-default-features) 
+> entries. As the intended  purpose of `default-features` is not to model the 
+> decisions made by upstream but to provide convenience for [classic mode](../concepts/classic-mode.md) 
+> users.
+
 Default features are intended to ensure that a reasonably functional build of a library gets installed for customers who don't know they are using it. If they don't know they are using a library, they can't know to list features. For example, `libarchive` exposes features that enable compression algorithms to an existing generic interface; if built without any of such features, the library may have no utility.
 
 One must carefully consider whether a feature should be on by default, because disabling default features is complex.
@@ -279,6 +286,7 @@ Disabling a default feature as a 'transitive' consumer requires:
 * Naming the transitive dependency on the `vcpkg install` command line, or as a direct dependency in the top level manifest
 
 In vcpkg's curated registry, if the feature adds additional APIs, executables, or other binaries, it must be off by default. If in doubt, do not mark a feature as default.
+ 
 
 ### Do not use features to control alternatives in published interfaces
 

--- a/vcpkg/maintainers/authoring-script-ports.md
+++ b/vcpkg/maintainers/authoring-script-ports.md
@@ -6,9 +6,9 @@ ms.author: viromer
 ms.date: 03/20/2024
 ms.topic: concept-article
 ---
-# Author helper ports
+# Authoring script ports
 
-Helper ports, also called script ports, expose functions for other ports to
+Script ports, also called helper ports, expose functions for other ports to
 consume during their build process. For instance, the `vcpkg-cmake` port defines
 the `vcpkg_cmake_configure()` function for other ports to consume. By packaging
 common scripts into a helper port, maintenance becomes more streamlined as
@@ -24,7 +24,7 @@ Before a port is executed, vcpkg will import any `vcpkg-port-config.cmake` file
 that has been exported by the direct dependencies of the port about to be
 executed.
 
-If a helper port depends on a different helper port, it must explicity import the
+If a helper port depends on a different helper port, it must explicitly import the
 `vcpkg-port-config.cmake` file of its dependency. Helper-to-helper port
 dependencies should not be marked as [host
 dependencies](../reference/vcpkg-json.md#dependency-host), this ensures that one
@@ -64,16 +64,15 @@ different helper port.
 `my-helper/portfile.cmake`
 
 ```cmake
-set(VCPKG_POLICY_HELPER_PORT enabled)
+set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
 
-file(INSTALL
-  "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake"
-  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/my_helper_function.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 file(INSTALL "${VCPKG_ROOT_DIR}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 ```
 
-By enabling the `VCPKG_POLICY_HELPER_PORT` policy, vcpkg enables post-build checks
+By enabling the `VCPKG_POLICY_CMAKE_HELPER_PORT` policy, vcpkg enables post-build checks
 that apply specifically to helper ports. Specifically, checks that `vcpkg-port-config.cmake` is
 installed in the correct path and that no files are installed in the `include` directory.
 

--- a/vcpkg/maintainers/functions/vcpkg_download_distfile.md
+++ b/vcpkg/maintainers/functions/vcpkg_download_distfile.md
@@ -26,7 +26,7 @@ directly, such as one of the following:
 
 ```cmake
 vcpkg_download_distfile(
-    <OUT_VARIABLE>
+    <out-var>
     URLS <http://mainUrl> <http://mirror1>...
     FILENAME <output.zip>
     SHA512 <5981de...>
@@ -36,10 +36,23 @@ vcpkg_download_distfile(
 
 ## Parameters
 
-### OUT_VARIABLE
+### out-var
 
-This variable will be set to the full path to the downloaded file. This can then immediately be passed to
-[`vcpkg_extract_source_archive`](vcpkg_extract_source_archive.md) for sources.
+The name of the out variable to be set with the full path to the downloaded file.
+
+This variable can then immediately be passed to [`vcpkg_extract_source_archive`](vcpkg_extract_source_archive.md)
+for sources.
+
+Conventionally, `ARCHIVE` is used as the out variable name.
+
+```cmake
+vcpkg_donwload_distfile(
+    ARCHIVE #this is the out-var
+    URLS "https://downloads.apache.org/apr/apr-${VERSION}.tar.bz2"
+    FILENAME "apr-${VERSION}.tar.bz2"
+    SHA512 629b60680d1244641828019db903a1b199e8a19c8f27a5132b93faacb381ce561f88463345ab019258f1f1e8cfdf8aa986ac815153a8e7e04a22b3932f9fedd2
+)
+```
 
 ### URLS
 

--- a/vcpkg/reference/binarycaching.md
+++ b/vcpkg/reference/binarycaching.md
@@ -190,6 +190,11 @@ Commas (`,`) are valid as part of a object prefix in GCS. Remember to escape the
 
 [!INCLUDE [experimental](../../includes/experimental.md)]
 
+> [!WARNING]
+> The `x-az-universal` provider is known to perform slowly with large numbers of
+> binary packages. The vcpkg team recommends using a different backend like
+> `x-azcopy` when possible.
+
 ```
 x-az-universal,<organization>,<project>,<feed>[,<rw>]
 ```


### PR DESCRIPTION
This PR makes the following changes:

* Add a note about the performance of the Universal Packages binary cache provider 
* Clarify the manifest mode tutorial by adding an extra header
* Clarify the usage of the out variable parameter in vcpkg_download_distfile
* Correct the required policy for helper ports and fix the installation of the example port
* Document our port renaming policy
* Clarify our stance on default-features being used to model upstream defaults