### PR TITLE
Document default z-applocal behavior

### DIFF
--- a/vcpkg/consume/classic-mode.md
+++ b/vcpkg/consume/classic-mode.md
@@ -3,7 +3,7 @@ title: "Tutorial: Install a dependency from the command line"
 description: Learn to install your project's dependencies with vcpkg using the command line.
 author: vicroms
 ms.author: viromer
-ms.date: 01/10/2024
+ms.date: 06/11/2026
 ms.topic: tutorial
 #CustomerIntent: As a beginner vcpkg user, I want to learn how to install my project dependencies using vcpkg's command-line interface.
 no-loc: [ triplet, port, baseline, overlay, classic, manifest, toolchain ]
@@ -176,8 +176,8 @@ ClCompile:
 Link:
   (omitted)
 AppLocalFromInstalled:
-  pwsh.exe -ExecutionPolicy Bypass -noprofile -File "D:\vcpkg\scripts\buildsystems\msbuild\applocal.ps1" "D:\projects\manifest-example\x64\Debug\manifest-example.exe"
-   "D:\vcpkg\installed\x64-windows\debug\bin" "x64\Debug\manifest-example.tlog\manifest-example.write.1u.tlog" "x64\Debug\vcpkg.applocal.log"
+  "D:\vcpkg\vcpkg.exe" z-applocal --target-binary="D:\projects\manifest-example\x64\Debug\manifest-example.exe"
+   --installed-bin-dir="D:\vcpkg\installed\x64-windows\debug\bin" --tlog-file="x64\Debug\manifest-example.tlog\manifest-example.write.1u.tlog" --copied-files-log="x64\Debug\vcpkg.applocal.log"
   D:\projects\manifest-example\x64\Debug\fmtd.dll
 FinalizeBuildStatus:
   Deleting file "x64\Debug\manifest-example.tlog\unsuccessfulbuild".

--- a/vcpkg/consume/manifest-mode.md
+++ b/vcpkg/consume/manifest-mode.md
@@ -3,7 +3,7 @@ title: "Tutorial: Install a dependency from a manifest file"
 description: Learn to install your projects dependencies with vcpkg by using a manifest file.
 author: vicroms
 ms.author: viromer
-ms.date: 01/10/2024
+ms.date: 06/11/2026
 ms.topic: tutorial
 #CustomerIntent: As a beginner vcpkg user, I want to learn how to install my project dependencies using vcpkg in manifest mode
 ---
@@ -214,9 +214,9 @@ ClCompile:
 Link:
   (omitted)
 AppLocalFromInstalled:
-  pwsh.exe -ExecutionPolicy Bypass -noprofile -File "D:\vcpkg\scripts\buildsystems\msbuild\applocal.ps1" "D:\projects\manif
-  est-mode-msbuild\x64\Debug\manifest-example.exe" "D:\projects\manifest-example\vcpkg_installed\x64-windows\x64-windows\debug\bin"
-  "x64\Debug\manifest.ceffc6eb.tlog\manifest-example.write.1u.tlog" "x64\Debug\vcpkg.applocal.log"
+  "D:\vcpkg\vcpkg.exe" z-applocal --target-binary="D:\projects\manifest-example\x64\Debug\manifest-example.exe"
+   --installed-bin-dir="D:\projects\manifest-example\vcpkg_installed\x64-windows\x64-windows\debug\bin"
+   --tlog-file="x64\Debug\manifest.ceffc6eb.tlog\manifest-example.write.1u.tlog" --copied-files-log="x64\Debug\vcpkg.applocal.log"
   D:\projects\manifest-example\x64\Debug\fmtd.dll
 FinalizeBuildStatus:
   (omitted)

--- a/vcpkg/maintainers/functions/vcpkg_copy_tool_dependencies.md
+++ b/vcpkg/maintainers/functions/vcpkg_copy_tool_dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: vcpkg_copy_tool_dependencies
 description: Learn how to use vcpkg_copy_tool_dependencies.
-ms.date: 01/10/2024
+ms.date: 06/11/2026
 ---
 # vcpkg_copy_tool_dependencies
 
@@ -20,6 +20,10 @@ The path to the directory containing the tools.
 ## Notes
 
 This command should always be called by portfiles after they have finished rearranging the binary output, if they have any tools.
+
+On Windows, this command uses the built-in `vcpkg z-applocal` implementation to copy dependencies by
+default. Set `VCPKG_USE_LEGACY_APPLOCAL` to use the legacy PowerShell `applocal.ps1`
+implementation.
 
 ## Source
 

--- a/vcpkg/users/buildsystems/cmake-integration.md
+++ b/vcpkg/users/buildsystems/cmake-integration.md
@@ -3,7 +3,7 @@ title: vcpkg in CMake projects
 description: Integrate vcpkg into a CMake project using a terminal, Visual Studio, Visual Studio Code, or other IDEs.
 author: vicroms
 ms.author: viromer
-ms.date: 01/10/2024
+ms.date: 06/11/2026
 ms.topic: concept-article
 ---
 # vcpkg in CMake projects
@@ -157,6 +157,21 @@ This variable sets the location where libraries will be installed and consumed f
 In manifest mode, the default is `${CMAKE_BINARY_DIR}/vcpkg_installed`.
 
 In classic mode, the default is `${VCPKG_ROOT}/installed`.
+
+### `VCPKG_APPLOCAL_DEPS`
+
+This option controls whether vcpkg automatically copies dependent DLLs into the output directory
+for executables and shared libraries on Windows, UWP, and Xbox targets. It defaults to `ON`.
+
+When this option is enabled, vcpkg uses the built-in `vcpkg z-applocal` implementation by default.
+
+### `VCPKG_USE_LEGACY_APPLOCAL`
+
+This option controls which app-local DLL deployment implementation vcpkg uses. It defaults to
+`OFF`, which uses the built-in `vcpkg z-applocal` implementation. Set it to `ON` to use the legacy
+PowerShell `applocal.ps1` implementation.
+
+This option has an effect only when vcpkg performs app-local DLL deployment.
 
 ### `VCPKG_MANIFEST_MODE`
 

--- a/vcpkg/users/buildsystems/cmake-integration.md
+++ b/vcpkg/users/buildsystems/cmake-integration.md
@@ -160,18 +160,14 @@ In classic mode, the default is `${VCPKG_ROOT}/installed`.
 
 ### `VCPKG_APPLOCAL_DEPS`
 
-This option controls whether vcpkg automatically copies dependent DLLs into the output directory
+This variable controls whether vcpkg automatically copies dependent DLLs into the output directory
 for executables and shared libraries on Windows, UWP, and Xbox targets. It defaults to `ON`.
-
-When this option is enabled, vcpkg uses the built-in `vcpkg z-applocal` implementation by default.
 
 ### `VCPKG_USE_LEGACY_APPLOCAL`
 
-This option controls which app-local DLL deployment implementation vcpkg uses. It defaults to
+This variable controls which app-local DLL deployment implementation vcpkg uses. It defaults to
 `OFF`, which uses the built-in `vcpkg z-applocal` implementation. Set it to `ON` to use the legacy
 PowerShell `applocal.ps1` implementation.
-
-This option has an effect only when vcpkg performs app-local DLL deployment.
 
 ### `VCPKG_MANIFEST_MODE`
 

--- a/vcpkg/users/buildsystems/msbuild-integration.md
+++ b/vcpkg/users/buildsystems/msbuild-integration.md
@@ -3,7 +3,7 @@ title: vcpkg in MSBuild projects
 description: Integrate vcpkg into an MSBuild or Visual Studio project.
 author: vicroms
 ms.author: viromer
-ms.date: 01/10/2024
+ms.date: 06/11/2026
 ms.topic: concept-article
 ---
 # vcpkg in MSBuild projects
@@ -212,13 +212,13 @@ classic mode, this defaults to `$(VcpkgRoot)\installed\`.
 ### `VcpkgApplocalDeps` (App-locally deploy DLLs)
 
 This property enables or disables detection and copying of dependent DLLs from the vcpkg installed
-tree to the project output directory.
+tree to the project output directory. It defaults to `true`.
 
 ### `VcpkgXUseBuiltInApplocalDeps` (Use built-in app-local deployment)
 
-This property, when enabled, uses vcpkg's experimental built-in app-local DLL deployment
-implementation when app-locally deploying DLLs. This property will be removed and have no effect
-when the built-in implementation is no longer experimental.
+This property controls which app-local DLL deployment implementation vcpkg uses when
+`VcpkgApplocalDeps` is enabled. It defaults to `true`, which uses the built-in `vcpkg z-applocal`
+implementation. Set it to `false` to use the legacy PowerShell `applocal.ps1` implementation.
 
 This property has no effect when `$(VcpkgApplocalDeps)` is false.
 


### PR DESCRIPTION
## Summary
- Document that built-in `vcpkg z-applocal` is now the default app-local deployment implementation
- Document legacy `applocal.ps1` fallback switches for MSBuild, CMake, and `vcpkg_copy_tool_dependencies`
- Update MSBuild tutorial output examples to show `z-applocal`

Documents microsoft/vcpkg#52315.